### PR TITLE
Fix reference to ASG

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -107,14 +107,16 @@ module Terrafying
         end
         tags = { Name: ident, service_name: name,}.merge(options[:tags]).map { |k,v| { Key: k, Value: v, PropagateAtLaunch: true }}
 
-        @asg = resource :aws_cloudformation_stack, ident, {
-                          name: ident,
-                          disable_rollback: true,
-                          template_body: generate_template(
-                            options[:health_check], options[:instances], launch_config,
-                            options[:subnets].map(&:id), tags, options[:rolling_update]
-                          ),
-                        }
+        asg = resource :aws_cloudformation_stack, ident, {
+                         name: ident,
+                         disable_rollback: true,
+                         template_body: generate_template(
+                           options[:health_check], options[:instances], launch_config,
+                           options[:subnets].map(&:id), tags, options[:rolling_update]
+                         ),
+                       }
+
+        @asg = output_of(:aws_cloudformation_stack, ident, 'outputs["AsgName"]')
 
         self
       end


### PR DESCRIPTION
When I dropped the pivot asg stuff I broke the reference to the
ASG inside of the cloud formation stack.