### PR TITLE
Allow reference to a self signed CAs key pair

### DIFF
--- a/lib/terrafying/components/templates/ignition.yaml
+++ b/lib/terrafying/components/templates/ignition.yaml
@@ -77,6 +77,11 @@ storage:
       contents: |
         <% cas.each { |ca| %><%= ca.source %>:/etc/ssl/<%= ca.name %>/ca.cert:0444<% } %>
         <% keypairs.each do |keypair| %>
+        <% if keypair.has_key?(:name) %>
         <%= keypair[:source][:cert] %>:/etc/ssl/<%= keypair[:ca].name %>/<%= keypair[:name] %>/cert:0444
         <%= keypair[:source][:key] %>:/etc/ssl/<%= keypair[:ca].name %>/<%= keypair[:name] %>/key:0444
+        <% else %>
+        <%= keypair[:source][:cert] %>:/etc/ssl/<%= keypair[:ca].name %>/ca.cert:0444
+        <%= keypair[:source][:key] %>:/etc/ssl/<%= keypair[:ca].name %>/ca.key:0444
+        <% end %>
         <% end %>

--- a/spec/terrafying/components/selfsignedca_spec.rb
+++ b/spec/terrafying/components/selfsignedca_spec.rb
@@ -6,4 +6,20 @@ RSpec.describe Terrafying::Components::SelfSignedCA do
 
   it_behaves_like "a CA"
 
+  it "should stick the ca key in s3 if it is referenced" do
+    ca = Terrafying::Components::SelfSignedCA.create("foo", "some-bucket")
+
+    expect(ca.output["resource"]["aws_s3_bucket_object"].select { |_, obj|
+             obj[:key].end_with?("ca.key")
+           }.count).to eq(0)
+
+    kp = ca.keypair
+
+    expect(ca.output["resource"]["aws_s3_bucket_object"].select { |_, obj|
+             obj[:key].end_with?("ca.key")
+           }.count).to eq(1)
+
+    expect(kp.has_key?(:name)).to be false
+  end
+
 end


### PR DESCRIPTION
We want to be able to include the CA's key on a server so we can
generate more certificates signed by the same CA.