### PR TITLE
Add fluentd audit forwarding config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
 
 Style/BracesAroundHashParameters:
   EnforcedStyle: braces

--- a/lib/terrafying/components/auditd.rb
+++ b/lib/terrafying/components/auditd.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Terrafying
+  module Components
+    class Auditd
+      def self.fluentd_conf(audit_role)
+        new.fluentd_conf(audit_role)
+      end
+
+      def fluentd_conf(audit_role)
+        {
+          files: [systemd_input, ec2_filter, s3_output(audit_role)]
+        }
+      end
+
+      def file_of(name, content)
+        {
+          path: "/etc/fluentd/conf.d/#{name}.conf",
+          mode: 0o644,
+          contents: content
+        }
+      end
+
+      def systemd_input
+        file_of(
+          '10_auditd_input_systemd',
+          <<~'SYSTEMD_INPUT'
+            <source>
+              @type systemd
+              tag auditd
+              filters [{ "_TRANSPORT": "audit" }, { "_COMM": "sshd" }]
+              path /fluentd/log/journal
+              read_from_head false
+              <storage>
+                @type local
+                persistent false
+                path /fluentd/var/audit.pos
+              </storage>
+              <entry>
+                field_map {
+                  "MESSAGE": "log",
+                  "_PID": ["process", "pid"],
+                  "_CMDLINE": "process",
+                  "_COMM": "cmd",
+                  "_AUDIT_SESSION": "audit_session",
+                  "_AUDIT_LOGINUID": "audit_loginuid"
+                }
+                fields_strip_underscores true
+                fields_lowercase true
+              </entry>
+            </source>
+          SYSTEMD_INPUT
+        )
+      end
+
+      def ec2_filter
+        file_of(
+          '20_auditd_filter_ec2',
+          <<~'EC2_FILTER'
+            <filter auditd>
+              @type ec2_metadata
+              metadata_refresh_seconds 300
+              <record>
+                name               ${tagset_name}
+                instance_id        ${instance_id}
+                instance_type      ${instance_type}
+                private_ip         ${private_ip}
+                az                 ${availability_zone}
+                vpc_id             ${vpc_id}
+                ami_id             ${image_id}
+                account_id         ${account_id}
+              </record>
+            </filter>
+          EC2_FILTER
+        )
+      end
+
+      def s3_output(audit_role)
+        file_of(
+          '30_auditd_output_s3',
+          <<~S3_OUTPUT
+            <match auditd>
+              @type s3
+              <assume_role_credentials>
+                role_arn #{audit_role}
+                role_session_name "auditd-logging-\#{Socket.gethostname}"
+              </assume_role_credentials>
+              auto_create_bucket false
+              s3_bucket uswitch-auditd-logs
+              s3_region eu-west-1
+              acl bucket-owner-full-control
+              path auditd/%Y/%m/%d/
+              s3_object_key_format "\%{path}\%{time_slice}_\#{Socket.gethostname}.\%{file_extension}"
+              <buffer time>
+                @type file
+                path /fluent/var/s3
+                timekey 300 # 5 minute partitions
+                timekey_wait 0s
+                timekey_use_utc true
+              </buffer>
+              <format>
+                @type json
+              </format>
+            </match>
+          S3_OUTPUT
+        )
+      end
+    end
+  end
+end

--- a/lib/terrafying/components/auditd.rb
+++ b/lib/terrafying/components/auditd.rb
@@ -3,7 +3,25 @@
 module Terrafying
   module Components
     class Auditd
-      DEFAULT_TAGS =
+      def self.fluentd_conf(options)
+        new.fluentd_conf(options)
+      end
+
+      def fluentd_conf(options)
+        options = {
+          tags: default_tags
+        }.deep_merge(options)
+
+        {
+          files: [
+            systemd_input,
+            ec2_filter(options[:tags]),
+            s3_output(options[:role])
+          ]
+        }
+      end
+
+      def default_tags
         {
           name:          'tagset_name',
           instance_id:   'instance_id',
@@ -13,23 +31,6 @@ module Terrafying
           vpc_id:        'vpc_id',
           ami_id:        'image_id',
           account_id:    'account_id'
-        }.freeze
-
-      def self.fluentd_conf(options)
-        new.fluentd_conf(options)
-      end
-
-      def fluentd_conf(options)
-        options = {
-          tags: DEFAULT_TAGS
-        }.deep_merge(options)
-
-        {
-          files: [
-            systemd_input,
-            ec2_filter(options[:tags]),
-            s3_output(options[:role])
-          ]
         }
       end
 

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -2,12 +2,14 @@
 require 'digest'
 require 'terrafying/generator'
 require 'terrafying/util'
+require 'terrafying/components/auditd'
 require 'terrafying/components/dynamicset'
 require 'terrafying/components/endpointservice'
 require 'terrafying/components/ignition'
 require 'terrafying/components/instance'
 require 'terrafying/components/instanceprofile'
 require 'terrafying/components/loadbalancer'
+require 'terrafying/components/selfsignedca'
 require 'terrafying/components/staticset'
 require 'terrafying/components/usable'
 
@@ -55,11 +57,13 @@ module Terrafying
           subnets: vpc.subnets.fetch(:private, []),
           startup_grace_period: 300,
           depends_on: [],
-          audit_role: "arn:aws:iam::#{aws.account_id}:role/auditd_logging"
+          audit: {
+            role: "arn:aws:iam::#{aws.account_id}:role/auditd_logging"
+          }
         }.merge(options)
 
-        unless options[:audit_role].nil?
-          fluentd_conf = Auditd.fluentd_conf(options[:audit_role])
+        unless options[:audit].nil? || options[:audit][:role].nil?
+          fluentd_conf = Auditd.fluentd_conf(options[:audit])
           options = options.merge({ files: options[:files] | fluentd_conf[:files] })
         end
 

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -55,7 +55,13 @@ module Terrafying
           subnets: vpc.subnets.fetch(:private, []),
           startup_grace_period: 300,
           depends_on: [],
+          audit_role: "arn:aws:iam::#{aws.account_id}:role/auditd_logging"
         }.merge(options)
+
+        unless options[:audit_role].nil?
+          fluentd_conf = Auditd.fluentd_conf(options[:audit_role])
+          options = options.merge({ files: options[:files] | fluentd_conf[:files] })
+        end
 
         if ! options.has_key? :user_data
           options[:user_data] = Ignition.generate(options)

--- a/lib/terrafying/components/version.rb
+++ b/lib/terrafying/components/version.rb
@@ -1,5 +1,5 @@
 module Terrafying
   module Components
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/spec/terrafying/components/auditd_spec.rb
+++ b/spec/terrafying/components/auditd_spec.rb
@@ -3,65 +3,52 @@
 require 'terrafying/components/auditd'
 
 def a_tag_matching(k, v)
+  a_file_matching(
+    '20_auditd_filter_ec2.conf',
+    a_string_matching(/#{k}\s+\$\{#{v}\}/)
+  )
+end
+
+def a_file_matching(file, content)
   a_hash_including(
     {
-      path: '/etc/fluentd/conf.d/20_auditd_filter_ec2.conf',
-      contents: a_string_matching(/#{k}\s+\$\{#{v}\}/)
+      path: "/etc/fluentd/conf.d/#{file}",
+      contents: a_string_matching(content)
     }
   )
 end
 
 RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
-  context('setting up auditd forwarding') do
-    it('should configure fluentd to read from the journal') do
+  context('audit log forwarding') do
+    it('should read from the journal') do
       conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
 
       expect(conf[:files]).to include(
-        a_hash_including(
-          {
-            path: '/etc/fluentd/conf.d/10_auditd_input_systemd.conf',
-            contents: a_string_matching('@type systemd')
-          }
-        )
+        a_file_matching('10_auditd_input_systemd.conf', '@type systemd')
       )
     end
 
-    it('should configure fluentd to add ec2 metadata') do
+    it('should add ec2 metadata') do
       conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
 
       expect(conf[:files]).to include(
-        a_hash_including(
-          {
-            path: '/etc/fluentd/conf.d/20_auditd_filter_ec2.conf',
-            contents: a_string_matching('@type ec2_metadata')
-          }
-        )
+        a_file_matching('20_auditd_filter_ec2.conf', '@type ec2_metadata')
       )
     end
 
-    it('should configure fluentd to output to s3') do
+    it('should output to s3') do
       conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
 
       expect(conf[:files]).to include(
-        a_hash_including(
-          {
-            path: '/etc/fluentd/conf.d/30_auditd_output_s3.conf',
-            contents: a_string_matching('@type s3')
-          }
-        )
+        a_file_matching('30_auditd_output_s3.conf', '@type s3')
       )
     end
 
-    it('should configure fluentd to output to s3 with a role assumed') do
+    it('should output to s3 with a role assumed') do
       conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
 
       expect(conf[:files]).to include(
-        a_hash_including(
-          {
-            path: '/etc/fluentd/conf.d/30_auditd_output_s3.conf',
-            contents: a_string_matching('role_arn a-role')
-          }
-        )
+        a_file_matching('30_auditd_output_s3.conf', 'role_arn a-role')
       )
     end
   end

--- a/spec/terrafying/components/auditd_spec.rb
+++ b/spec/terrafying/components/auditd_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'terrafying/components/auditd'
+
+RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
+  context('setting up auditd forwarding') do
+    it('should configure fluentd to read from the journal') do
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
+
+      expect(conf[:files]).to include(
+        a_hash_including(
+          {
+            path: '/etc/fluentd/conf.d/10_auditd_input_systemd.conf',
+            contents: a_string_matching('@type systemd')
+          }
+        )
+      )
+    end
+
+    it('should configure fluentd to add ec2 metadata') do
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
+
+      expect(conf[:files]).to include(
+        a_hash_including(
+          {
+            path: '/etc/fluentd/conf.d/20_auditd_filter_ec2.conf',
+            contents: a_string_matching('@type ec2_metadata')
+          }
+        )
+      )
+    end
+
+    it('should configure fluentd to output to s3') do
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
+
+      expect(conf[:files]).to include(
+        a_hash_including(
+          {
+            path: '/etc/fluentd/conf.d/30_auditd_output_s3.conf',
+            contents: a_string_matching('@type s3')
+          }
+        )
+      )
+    end
+
+    it('should configure fluentd to output to s3 with a role assumed') do
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
+
+      expect(conf[:files]).to include(
+        a_hash_including(
+          {
+            path: '/etc/fluentd/conf.d/30_auditd_output_s3.conf',
+            contents: a_string_matching('role_arn a-role')
+          }
+        )
+      )
+    end
+  end
+end

--- a/spec/terrafying/components/auditd_spec.rb
+++ b/spec/terrafying/components/auditd_spec.rb
@@ -2,10 +2,19 @@
 
 require 'terrafying/components/auditd'
 
+def a_tag_matching(k, v)
+  a_hash_including(
+    {
+      path: '/etc/fluentd/conf.d/20_auditd_filter_ec2.conf',
+      contents: a_string_matching(/#{k}\s+\$\{#{v}\}/)
+    }
+  )
+end
+
 RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
   context('setting up auditd forwarding') do
     it('should configure fluentd to read from the journal') do
-      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
 
       expect(conf[:files]).to include(
         a_hash_including(
@@ -18,7 +27,7 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
     end
 
     it('should configure fluentd to add ec2 metadata') do
-      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
 
       expect(conf[:files]).to include(
         a_hash_including(
@@ -31,7 +40,7 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
     end
 
     it('should configure fluentd to output to s3') do
-      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
 
       expect(conf[:files]).to include(
         a_hash_including(
@@ -44,7 +53,7 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
     end
 
     it('should configure fluentd to output to s3 with a role assumed') do
-      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
 
       expect(conf[:files]).to include(
         a_hash_including(
@@ -54,6 +63,56 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
           }
         )
       )
+    end
+  end
+
+  context('default ec2 metadata tags') do
+    it('should add name tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      expect(conf[:files]).to include(a_tag_matching('name', 'tagset_name'))
+    end
+
+    it('should add instance_id tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      expect(conf[:files]).to include(a_tag_matching('instance_id', 'instance_id'))
+    end
+
+    it('should add instance_type tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      expect(conf[:files]).to include(a_tag_matching('instance_type', 'instance_type'))
+    end
+
+    it('should add private_ip tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      expect(conf[:files]).to include(a_tag_matching('private_ip', 'private_ip'))
+    end
+
+    it('should add az tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      expect(conf[:files]).to include(a_tag_matching('az', 'availability_zone'))
+    end
+
+    it('should add vpc_id tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      expect(conf[:files]).to include(a_tag_matching('vpc_id', 'vpc_id'))
+    end
+
+    it('should add ami_id tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      expect(conf[:files]).to include(a_tag_matching('ami_id', 'image_id'))
+    end
+
+    it('should add account_id tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      expect(conf[:files]).to include(a_tag_matching('account_id', 'account_id'))
+    end
+  end
+
+  context('custom ec2 metadata tags') do
+    it('should add my_tag tag') do
+      conf = Terrafying::Components::Auditd.fluentd_conf({ role: 'a-role', tags: { my_tag: 'tagset_my_tag' } })
+
+      expect(conf[:files]).to include(a_tag_matching('my_tag', 'tagset_my_tag'))
     end
   end
 end

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -1,6 +1,6 @@
+require 'base64'
 require 'terrafying'
 require 'terrafying/components/service'
-
 
 RSpec.describe Terrafying::Components::Service do
 
@@ -36,6 +36,36 @@ RSpec.describe Terrafying::Components::Service do
     unit_contents = unit[:contents].dump[1..-2]
 
     expect(output["resource"]["aws_instance"].values.first[:user_data]).to include(unit_contents)
+  end
+
+  it 'should add fluentd config for auditd logs to user data if user data not explicitly given' do
+    unit = Terrafying::Components::Ignition.container_unit('app', 'app:latest')
+    service = Terrafying::Components::Service.create_in(
+      @vpc, 'foo', {
+        units: [unit]
+      }
+    )
+
+    output = service.output_with_children
+
+    expect(output['resource']['aws_instance'].values.first[:user_data]).to include('/etc/fluentd/conf.d')
+  end
+
+  it 'should add fluentd config for auditd logs to user data with the audit role specified' do
+    unit = Terrafying::Components::Ignition.container_unit('app', 'app:latest')
+    service = Terrafying::Components::Service.create_in(
+      @vpc, 'foo', {
+        units: [unit]
+      }
+    )
+
+    user_data = service.output_with_children['resource']['aws_instance'].values.first[:user_data]
+    files = JSON.parse(user_data, { symbolize_names: true })[:storage][:files]
+
+    conf_file = files.find { |f| f[:path] == '/etc/fluentd/conf.d/30_auditd_output_s3.conf' }
+    conf_content = Base64.decode64(conf_file[:contents][:source].sub(/^[^,]*,/, ''))
+
+    expect(conf_content).to include('role_arn arn:aws:iam::1234:role/auditd_logging')
   end
 
   it "should depend on any key pairs passed in" do

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Terrafying::Components::Service do
     expect(output['resource']['aws_instance'].values.first[:user_data]).to include('/etc/fluentd/conf.d')
   end
 
-  it 'should add fluentd config for auditd logs to user data with the audit role specified' do
+  it 'should add fluentd config for auditd logs to user data with the default audit role' do
     unit = Terrafying::Components::Ignition.container_unit('app', 'app:latest')
     service = Terrafying::Components::Service.create_in(
       @vpc, 'foo', {
@@ -66,6 +66,26 @@ RSpec.describe Terrafying::Components::Service do
     conf_content = Base64.decode64(conf_file[:contents][:source].sub(/^[^,]*,/, ''))
 
     expect(conf_content).to include('role_arn arn:aws:iam::1234:role/auditd_logging')
+  end
+
+  it 'should add fluentd config for auditd logs to user data with the audit role specified' do
+    unit = Terrafying::Components::Ignition.container_unit('app', 'app:latest')
+    service = Terrafying::Components::Service.create_in(
+      @vpc, 'foo', {
+        units: [unit],
+        audit: {
+          role: 'an-audit-role'
+        }
+      }
+    )
+
+    user_data = service.output_with_children['resource']['aws_instance'].values.first[:user_data]
+    files = JSON.parse(user_data, { symbolize_names: true })[:storage][:files]
+
+    conf_file = files.find { |f| f[:path] == '/etc/fluentd/conf.d/30_auditd_output_s3.conf' }
+    conf_content = Base64.decode64(conf_file[:contents][:source].sub(/^[^,]*,/, ''))
+
+    expect(conf_content).to include('role_arn an-audit-role')
   end
 
   it "should depend on any key pairs passed in" do


### PR DESCRIPTION
Allow for Audit role config in terrafying components now that we've removed the specific role from the cloud base image. This will also bump the version to 1.1.0.

See this PR: https://github.com/uswitch/cloud-base-image/pull/12