### PR TITLE
Extend Fluentd Audit config to cover Tags and IAM Policy

### DIFF
--- a/lib/terrafying/components/auditd.rb
+++ b/lib/terrafying/components/auditd.rb
@@ -3,22 +3,31 @@
 module Terrafying
   module Components
     class Auditd
-      def self.fluentd_conf(options)
-        new.fluentd_conf(options)
+      def self.fluentd_conf(role, tags = [])
+        new.fluentd_conf(role, tags)
       end
 
-      def fluentd_conf(options)
-        options = {
-          tags: default_tags
-        }.deep_merge(options)
+      def fluentd_conf(role, tags)
+        tags = default_tags.merge(
+          custom_tags(tags)
+        )
 
         {
           files: [
             systemd_input,
-            ec2_filter(options[:tags]),
-            s3_output(options[:role])
+            ec2_filter(tags),
+            s3_output(role)
           ]
         }
+      end
+
+      def custom_tags(tags)
+        tags.map { |t| [t, wrap_tag(t)] }.to_h
+      end
+
+      def wrap_tag(t)
+        t = "tagset_#{t}" unless t.start_with? 'tagset_'
+        t.downcase
       end
 
       def default_tags

--- a/lib/terrafying/components/auditd.rb
+++ b/lib/terrafying/components/auditd.rb
@@ -17,6 +17,9 @@ module Terrafying
             systemd_input,
             ec2_filter(tags),
             s3_output(role)
+          ],
+          iam_policy_statements: [
+            allow_assume(role)
           ]
         }
       end
@@ -40,6 +43,14 @@ module Terrafying
           vpc_id:        'vpc_id',
           ami_id:        'image_id',
           account_id:    'account_id'
+        }
+      end
+
+      def allow_assume(role)
+        {
+          Effect: 'Allow',
+          Action: ['sts:AssumeRole'],
+          Resource: [role]
         }
       end
 

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -57,13 +57,11 @@ module Terrafying
           subnets: vpc.subnets.fetch(:private, []),
           startup_grace_period: 300,
           depends_on: [],
-          audit: {
-            role: "arn:aws:iam::#{aws.account_id}:role/auditd_logging"
-          }
+          audit_role: "arn:aws:iam::#{aws.account_id}:role/auditd_logging"
         }.merge(options)
 
-        unless options[:audit].nil? || options[:audit][:role].nil?
-          fluentd_conf = Auditd.fluentd_conf(options[:audit])
+        unless options[:audit_role].nil?
+          fluentd_conf = Auditd.fluentd_conf(options[:audit_role], options[:tags].keys)
           options = options.merge({ files: options[:files] | fluentd_conf[:files] })
         end
 

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -62,7 +62,7 @@ module Terrafying
 
         unless options[:audit_role].nil?
           fluentd_conf = Auditd.fluentd_conf(options[:audit_role], options[:tags].keys)
-          options = options.merge({ files: options[:files] | fluentd_conf[:files] })
+          options = options.deep_merge(fluentd_conf)
         end
 
         if ! options.has_key? :user_data

--- a/spec/terrafying/components/auditd_spec.rb
+++ b/spec/terrafying/components/auditd_spec.rb
@@ -21,7 +21,7 @@ end
 RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
   context('audit log forwarding') do
     it('should read from the journal') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
 
       expect(conf[:files]).to include(
         a_file_matching('10_auditd_input_systemd.conf', '@type systemd')
@@ -29,7 +29,7 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
     end
 
     it('should add ec2 metadata') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
 
       expect(conf[:files]).to include(
         a_file_matching('20_auditd_filter_ec2.conf', '@type ec2_metadata')
@@ -37,7 +37,7 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
     end
 
     it('should output to s3') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
 
       expect(conf[:files]).to include(
         a_file_matching('30_auditd_output_s3.conf', '@type s3')
@@ -45,7 +45,7 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
     end
 
     it('should output to s3 with a role assumed') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
 
       expect(conf[:files]).to include(
         a_file_matching('30_auditd_output_s3.conf', 'role_arn a-role')
@@ -55,49 +55,49 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
 
   context('default ec2 metadata tags') do
     it('should add name tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
       expect(conf[:files]).to include(a_tag_matching('name', 'tagset_name'))
     end
 
     it('should add instance_id tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
       expect(conf[:files]).to include(a_tag_matching('instance_id', 'instance_id'))
     end
 
     it('should add instance_type tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
       expect(conf[:files]).to include(a_tag_matching('instance_type', 'instance_type'))
     end
 
     it('should add private_ip tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
       expect(conf[:files]).to include(a_tag_matching('private_ip', 'private_ip'))
     end
 
     it('should add az tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
       expect(conf[:files]).to include(a_tag_matching('az', 'availability_zone'))
     end
 
     it('should add vpc_id tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
       expect(conf[:files]).to include(a_tag_matching('vpc_id', 'vpc_id'))
     end
 
     it('should add ami_id tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
       expect(conf[:files]).to include(a_tag_matching('ami_id', 'image_id'))
     end
 
     it('should add account_id tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf role: 'a-role'
+      conf = Terrafying::Components::Auditd.fluentd_conf 'a-role'
       expect(conf[:files]).to include(a_tag_matching('account_id', 'account_id'))
     end
   end
 
   context('custom ec2 metadata tags') do
     it('should add my_tag tag') do
-      conf = Terrafying::Components::Auditd.fluentd_conf({ role: 'a-role', tags: { my_tag: 'tagset_my_tag' } })
+      conf = Terrafying::Components::Auditd.fluentd_conf('a-role', ['my_tag'])
 
       expect(conf[:files]).to include(a_tag_matching('my_tag', 'tagset_my_tag'))
     end

--- a/spec/terrafying/components/auditd_spec.rb
+++ b/spec/terrafying/components/auditd_spec.rb
@@ -102,4 +102,20 @@ RSpec.describe Terrafying::Components::Auditd, '#fluentd_conf' do
       expect(conf[:files]).to include(a_tag_matching('my_tag', 'tagset_my_tag'))
     end
   end
+
+  context('iam roles') do
+    it('should allow the instance to assume the audit role') do
+      conf = Terrafying::Components::Auditd.fluentd_conf('a-role', ['my_tag'])
+
+      expect(conf[:iam_policy_statements]).to include(
+        a_hash_including(
+          {
+            Effect: 'Allow',
+            Action: ['sts:AssumeRole'],
+            Resource: ['a-role']
+          }
+        )
+      )
+    end
+  end
 end

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -73,9 +73,7 @@ RSpec.describe Terrafying::Components::Service do
     service = Terrafying::Components::Service.create_in(
       @vpc, 'foo', {
         units: [unit],
-        audit: {
-          role: 'an-audit-role'
-        }
+        audit_role: 'an-audit-role'
       }
     )
 


### PR DESCRIPTION
This adds two new bits to the fluentd config.

- Add instance tags to forwarded auditd entries
In the past these were manually configured on a per image basis and mostly only used to forward the kubernetes cluster names for easier grepping on ES. This will now be automatically applied for all user tags set on an instance.

- Allow instance to assume the specified logging role
All instances that have an audit role specified will be allowed to assume that role via the instance profile.