### PR TITLE
Static IP address for VPN

### DIFF
--- a/lib/terrafying/components/vpn.rb
+++ b/lib/terrafying/components/vpn.rb
@@ -44,6 +44,7 @@ module Terrafying
           cidr: "10.8.0.0/24",
           public: true,
           subnets: vpc.subnets.fetch(:public, []),
+          static: false,
           route_all_traffic: false,
           units: [],
           tags: {}
@@ -87,6 +88,13 @@ module Terrafying
           keypairs.push(options[:ca].create_keypair_in(self, @fqdn))
         end
 
+        if options[:static]
+          subnet = options[:subnets].first
+          instances = [{ subnet: subnet, ip_address: subnet.ip_addresses.first }]
+        else
+          instances = [{}]
+        end
+
         @service = add! Service.create_in(
                           vpc, name,
                           {
@@ -97,6 +105,7 @@ module Terrafying
                             files: files,
                             keypairs: keypairs,
                             subnets: options[:subnets],
+                            instances: instances,
                             iam_policy_statements: [
                               {
                                 Effect: "Allow",


### PR DESCRIPTION
We have a situation where we need a consistent IP address for the VPN
server that is pingable. ICMP has been solved elsewhere, this allows us
to make a VPN static