### PR TITLE
Enlarge letsencrypt renewal window

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -77,6 +77,7 @@ module Terrafying
           ],
           dns_names: [],
           ip_addresses: [],
+          min_days_remaining: 21,
         }.merge(options)
 
         key_ident = "#{@name}-#{tf_safe(name)}"
@@ -101,6 +102,7 @@ module Terrafying
                        server_url: @server_url,
                        account_key_pem: @account_key,
                        registration_url: @registration_url,
+                       min_days_remaining: options[:min_days_remaining],
                        dns_challenge: {
                          provider: "route53",
                        },


### PR DESCRIPTION
By default it waits until 7 days before the cert is expired before
renewing. This widens that gap a bit