### PR TITLE
In the context of IPv4 CIDRS, pingv6 is not needed

### DIFF
--- a/lib/terrafying/components/usable.rb
+++ b/lib/terrafying/components/usable.rb
@@ -39,15 +39,6 @@ module Terrafying
                      to_port: 0, # icmp code
                      cidr_blocks: cidrs,
                    }
-
-        resource :aws_security_group_rule, "#{@name}-to-#{ident}-pingv6", {
-                   security_group_id: self.ingress_security_group,
-                   type: "ingress",
-                   protocol: 58, # icmpv6
-                   from_port: 128, # icmp type
-                   to_port: 0, # icmp code
-                   cidr_blocks: cidrs,
-                 }
       end
 
       def used_by_cidr(*cidrs)

--- a/spec/support/shared_examples/usable.rb
+++ b/spec/support/shared_examples/usable.rb
@@ -77,17 +77,6 @@ shared_examples "a usable resource" do
         rule[:protocol] == 1
       }
     ).to be true
-
-    expect(
-      output["resource"]["aws_security_group_rule"].any? { |_, rule|
-        rule[:type] == "ingress" && \
-        rule.has_key?(:cidr_blocks) && \
-        rule[:cidr_blocks] == cidrs && \
-        rule[:from_port] == 128 && \
-        rule[:to_port] == 0 && \
-        rule[:protocol] == 58
-      }
-    ).to be true
   end
 
   it "should add ingress that maps the right resources" do


### PR DESCRIPTION
When we talk CIDRs we only talk IPv4, so opening up IPv6 to IPv4
CIDRs seems redundant