### PR TITLE
CAs should allow the certificates to be public

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -30,6 +30,7 @@ module Terrafying
           prefix: "",
           provider: :staging,
           email_address: "cloud@uswitch.com",
+          public_certificate: false,
         }.merge(options)
 
         @name = name
@@ -59,10 +60,17 @@ module Terrafying
                    content: @account_key,
                  }
 
+        if options[:public_certificate]
+          cert_acl = "public-read"
+        else
+          cert_acl = "private"
+        end
+
         resource :aws_s3_bucket_object, "#{@name}-cert", {
                    bucket: @bucket,
                    key: File.join(@prefix, @name, "ca.cert"),
                    content: "we don't care as it's trusted, just want parity",
+                   acl: cert_acl,
                  }
 
         @source = File.join("s3://", @bucket, @prefix, @name, "ca.cert")

--- a/lib/terrafying/components/selfsignedca.rb
+++ b/lib/terrafying/components/selfsignedca.rb
@@ -25,6 +25,7 @@ module Terrafying
           prefix: "",
           common_name: name,
           organization: "uSwitch Limited",
+          public_certificate: false,
         }.merge(options)
 
         @name = name
@@ -60,10 +61,17 @@ module Terrafying
         @ca_key = output_of(:tls_private_key, @ident, :private_key_pem)
         @ca_cert = output_of(:tls_self_signed_cert, @ident, :cert_pem)
 
+        if options[:public_certificate]
+          cert_acl = "public-read"
+        else
+          cert_acl = "private"
+        end
+
         resource :aws_s3_bucket_object, "#{@name}-cert", {
                    bucket: @bucket,
                    key: File.join(@prefix, @name, "ca.cert"),
                    content: @ca_cert,
+                   acl: cert_acl,
                  }
 
         self

--- a/spec/support/shared_examples/ca.rb
+++ b/spec/support/shared_examples/ca.rb
@@ -33,6 +33,28 @@ shared_examples "a CA" do
       expect(@ca.name).to eq(ca_name)
     end
 
+    describe "certificate acl" do
+      it "should be private by default" do
+        ca_cert = @ca.output["resource"]["aws_s3_bucket_object"].values.select { |object|
+          object[:key].end_with?("ca.cert")
+        }
+
+        expect(ca_cert.count).to eq(1)
+        expect(ca_cert[0][:acl]).to eq("private")
+      end
+
+      it "should be public when wanted" do
+        ca = described_class.create(ca_name, bucket_name, public_certificate: true)
+
+        ca_cert = ca.output["resource"]["aws_s3_bucket_object"].values.select { |object|
+          object[:key].end_with?("ca.cert")
+        }
+
+        expect(ca_cert.count).to eq(1)
+        expect(ca_cert[0][:acl]).to eq("public-read")
+      end
+  end
+
   end
 
   describe ".create_keypair_in" do


### PR DESCRIPTION
We want to be able to configure the CA cert to be public so people
outside of our AWS account can download it.