### PR TITLE
Make Usable work with an NLB when attached

### DIFF
--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -1,4 +1,6 @@
 
+require 'xxhash'
+
 require 'terrafying/components/usable'
 
 module Terrafying

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -147,6 +147,10 @@ module Terrafying
       def attach(set)
         if set.respond_to?(:attach_load_balancer)
           set.attach_load_balancer(self)
+
+          if @type == "network"
+            @security_group = set.ingress_security_group
+          end
         else
           raise "Dont' know how to attach object to LB"
         end

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe Terrafying::Components::Service do
       expect(instance_to_lb_rules[0][:to_port]).to eq(443)
     end
 
-    it "should create no security groups, beyond path mtu, for NLBs" do
+    it "should create no security groups for NLBs" do
       service = Terrafying::Components::Service.create_in(
         @vpc, "foo", {
           instances: { min: 1, max: 1, desired: 1, tags: {} },
@@ -341,7 +341,7 @@ RSpec.describe Terrafying::Components::Service do
       }
       instance_to_lb_rules = instance_rules.select { |r| r[:source_security_group_id] == service.load_balancer.security_group }
 
-      expect(instance_to_lb_rules.count).to eq(1)
+      expect(instance_to_lb_rules.count).to eq(0)
     end
 
     it "shouldn't use ALB as egress security group when binding services" do

--- a/terrafying-components.gemspec
+++ b/terrafying-components.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-mocks', '~> 3.7'
 
   spec.add_runtime_dependency 'terrafying', '~> 1'
+  spec.add_runtime_dependency 'xxhash', '~> 0.4.0'
 end


### PR DESCRIPTION
If you've attached an NLB to a set of instances a user of terrafying
would likely expect that making the LB by used by some cidrs or
other services would actually work.

This ensures that once attached, the sec group is populated and usable
functions work.