### PR TITLE
Use rake tasks to version, build and push

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,11 +1,19 @@
 pipeline:
   test:
-    image: ruby:2.5.1
+    image: ruby:2.5
     commands:
       - bundle install
-      - bundle exec rake
+      - rake spec
     when:
       event: push
+
+  build:
+    image: ruby:2.5
+    commands:
+      - rake version
+      - rake build
+    when:
+      event: [push, tag]
 
   docker:
     image: plugins/docker
@@ -18,23 +26,21 @@ pipeline:
     when:
       event: push
 
+  push:
+    image: ruby:2.5
+    secrets: [ rubygems_api_key ]
+    commands:
+      - rake push
+    when:
+      event: tag
+      branch: master
+
   docker-tag:
     image: plugins/docker
     repo: quay.io/uswitch/terrafying-components
     registry: quay.io
     secrets: [ docker_username, docker_password ]
     auto_tag: true
-    when:
-      event: [push, tag]
-
-  rubygems:
-    image: ruby:2.4
-    secrets: [ rubygems_api_key ]
-    commands:
-      - bundle install
-      - sed -i 's/0\.0\.0/${DRONE_TAG}/' lib/terrafying/components/version.rb
-      - gem build terrafying-components.gemspec
-      - bundle exec rake push
     when:
       event: tag
       branch: master

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,15 @@
+.gemconfig
 .nix-gems
-tmp/
-.bundle
 .idea
+
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,2 @@
 AllCops:
   TargetRubyVersion: 2.4
-
-Style/BracesAroundHashParameters:
-  EnforcedStyle: braces

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --update --no-cache --virtual .terra-builddeps build-base ruby-dev \
  && apk add --update --no-cache --virtual .terra-rundeps git \
  && cd /usr/src/app \
  && bundle install \
+ && rake install \
  && install -d /terra \
  && apk del .terra-builddeps \
  && rm -rf /var/cache/apk/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,7 @@ PATH
   remote: .
   specs:
     terrafying-components (0.0.0)
-      netaddr (~> 1.5)
       terrafying (~> 1)
-      xxhash (~> 0.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -25,7 +23,7 @@ GEM
     aws-sdk-ec2 (1.34.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-elasticloadbalancingv2 (1.8.0)
+    aws-sdk-elasticloadbalancingv2 (1.9.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
     aws-sdk-kms (1.5.0)
@@ -83,4 +81,4 @@ DEPENDENCIES
   terrafying-components!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,23 +1,33 @@
 # frozen_string_literal: true
 
+require 'bundler/gem_tasks'
+require 'yaml'
+
+rubygems_api_key   = ENV['RUBYGEMS_API_KEY']
+terrafying_version = Terrafying::Components::VERSION
+
 begin
   require 'rspec/core/rake_task'
 
   RSpec::Core::RakeTask.new(:spec)
-  task :default => :spec
+  task default: :spec
 rescue LoadError
   # no rspec available
 end
 
+desc 'Push gem to rubygems'
 task :push do
-  gem_config = <<-GEM_CONFIG
----
-:rubygems_api_key: #{ENV['RUBYGEMS_API_KEY']}
-GEM_CONFIG
-
+  gem_config = { rubygems_api_key: rubygems_api_key }.to_yaml
   File.open('.gemconfig', 'w') { |file| file.write(gem_config) }
-
-  tag = ENV['DRONE_TAG']
-
-  `gem push --config-file .gemconfig terrafying-components-#{tag}.gem`
+  sh("gem push --config-file .gemconfig pkg/terrafying-components-#{terrafying_version}.gem")
 end
+
+desc 'Update the version for terrafying-components to DRONE_TAG. (0.0.0 if DRONE_TAG not set)'
+task :version do
+  ver = ENV['DRONE_TAG'] || '0.0.0'
+  version_file = 'lib/terrafying/components/version.rb'
+  content = File.read(version_file).gsub(/0\.0\.0/, ver)
+  File.open(version_file, 'w') { |file| file.puts content }
+end
+
+task push: :build

--- a/terrafying-components.gemspec
+++ b/terrafying-components.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{No.}
   spec.homepage      = "https://github.com/uswitch/terrafying-components"
 
+  spec.files         = `git ls-files lib/`.split($RS)
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'bundler', '~> 1.11'
@@ -21,7 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'rspec-mocks', '~> 3.7'
 
-  spec.add_runtime_dependency 'netaddr', '~> 1.5'
   spec.add_runtime_dependency 'terrafying', '~> 1'
-  spec.add_runtime_dependency 'xxhash', '~> 0.4.0'
 end


### PR DESCRIPTION
This reworks our existing rakefile and drone build to seperate the gem build from the push.

We test and then build a versioned gem for each push and tag and images will have the actual gem installed into it instead of it being used from source.

On tag+master the gem will be pushed to rubygems.
