### PR TITLE
Add basic support for defining a port range for a service

### DIFF
--- a/lib/terrafying/components/ports.rb
+++ b/lib/terrafying/components/ports.rb
@@ -26,6 +26,20 @@ def enrich_ports(ports)
   }
 end
 
+def from_port(port)
+  return port unless port_range?(port)
+  port.split('-').first.to_i
+end
+
+def to_port(port)
+  return port unless port_range?(port)
+  port.split('-').last.to_i
+end
+
+def port_range?(port)
+  port.is_a?(String) && port.match(/[0-9]+-[0-9]+/)
+end
+
 def is_l4_port(port)
   port[:type] == "tcp" || port[:type] == "udp"
 end

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -103,8 +103,8 @@ module Terrafying
           resource :aws_security_group_rule, "#{@name}-to-self-#{port[:name]}", {
                      security_group_id: @security_group,
                      type: "ingress",
-                     from_port: port[:upstream_port],
-                     to_port: port[:upstream_port],
+                     from_port: from_port(port[:upstream_port]),
+                     to_port: to_port(port[:upstream_port]),
                      protocol: port[:type],
                      self: true,
                    }

--- a/lib/terrafying/components/usable.rb
+++ b/lib/terrafying/components/usable.rb
@@ -49,8 +49,8 @@ module Terrafying
             resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}", {
                        security_group_id: self.ingress_security_group,
                        type: "ingress",
-                       from_port: port[:upstream_port],
-                       to_port: port[:upstream_port],
+                       from_port: from_port(port[:upstream_port]),
+                       to_port: to_port(port[:upstream_port]),
                        protocol: port[:type] == "udp" ? "udp" : "tcp",
                        cidr_blocks: [cidr],
                      }
@@ -104,8 +104,8 @@ module Terrafying
             resource :aws_security_group_rule, "#{@name}-to-#{other_resource.name}-#{port[:name]}", {
                        security_group_id: self.ingress_security_group,
                        type: "ingress",
-                       from_port: port[:upstream_port],
-                       to_port: port[:upstream_port],
+                       from_port: from_port(port[:upstream_port]),
+                       to_port: to_port(port[:upstream_port]),
                        protocol: port[:type] == "udp" ? "udp" : "tcp",
                        source_security_group_id: other_resource.egress_security_group,
                      }
@@ -113,8 +113,8 @@ module Terrafying
             resource :aws_security_group_rule, "#{other_resource.name}-to-#{@name}-#{port[:name]}", {
                        security_group_id: other_resource.egress_security_group,
                        type: "egress",
-                       from_port: port[:downstream_port],
-                       to_port: port[:downstream_port],
+                       from_port: from_port(port[:downstream_port]),
+                       to_port: to_port(port[:downstream_port]),
                        protocol: port[:type] == "udp" ? "udp" : "tcp",
                        source_security_group_id: self.ingress_security_group,
                      }

--- a/spec/support/shared_examples/usable.rb
+++ b/spec/support/shared_examples/usable.rb
@@ -159,4 +159,45 @@ shared_examples "a usable resource" do
     ).to be true
   end
 
+  it 'should map from and to port when a range is passed in' do
+    test_resource = described_class.create_in(
+      @vpc, 'some-thing', {
+        ports: [
+          number: '1000-1200'
+        ]
+      }
+    )
+
+    test_resource.used_by_cidr('10.1.0.0/16')
+
+    rules = test_resource.output_with_children['resource']['aws_security_group_rule'].values
+
+    expect(rules).to include(
+      a_hash_including(
+        from_port: 1000,
+        to_port:   1200
+      )
+    )
+  end
+
+  it 'should map port when a number is passed in' do
+    test_resource = described_class.create_in(
+      @vpc, 'some-thing', {
+        ports: [
+          number: 1200
+        ]
+      }
+    )
+
+    test_resource.used_by_cidr('10.1.0.0/16')
+
+    rules = test_resource.output_with_children['resource']['aws_security_group_rule'].values
+
+    expect(rules).to include(
+      a_hash_including(
+        from_port: 1200,
+        to_port:   1200
+      )
+    )
+  end
 end


### PR DESCRIPTION
Allow specifying a port range as a string in the form of `<FROM_PORT>-<TO_PORT>` as the port number.