### PR TITLE
Filter ports

### DIFF
--- a/lib/terrafying/components/usable.rb
+++ b/lib/terrafying/components/usable.rb
@@ -43,7 +43,7 @@ module Terrafying
 
       def used_by_cidr(*cidrs, &block)
         cidrs.map do |cidr|
-          cidr_ident = cidr.gsub('./', '-')
+          cidr_ident = cidr.tr('./', '-')
 
           @ports.select(&block).map do |port|
             resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}", {

--- a/lib/terrafying/components/usable.rb
+++ b/lib/terrafying/components/usable.rb
@@ -42,20 +42,20 @@ module Terrafying
       end
 
       def used_by_cidr(*cidrs, &block)
-        cidrs.map do |cidr|
+        cidrs.map { |cidr|
           cidr_ident = cidr.tr('./', '-')
 
-          @ports.select(&block).map do |port|
+          @ports.select(&block).map { |port|
             resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}", {
-              security_group_id: ingress_security_group,
-              type: 'ingress',
-              from_port: from_port(port[:upstream_port]),
-              to_port: to_port(port[:upstream_port]),
-              protocol: port[:type] == 'udp' ? 'udp' : 'tcp',
-              cidr_blocks: [cidr]
-            }
-          end
-        end
+                       security_group_id: ingress_security_group,
+                       type: "ingress",
+                       from_port: from_port(port[:upstream_port]),
+                       to_port: to_port(port[:upstream_port]),
+                       protocol: port[:type] == "udp" ? "udp" : "tcp",
+                       cidr_blocks: [cidr]
+                     }
+          }
+        }
       end
 
       def pingable_by(*other_resources)
@@ -98,9 +98,9 @@ module Terrafying
         }
       end
 
-      def used_by(*other_resources)
+      def used_by(*other_resources, &block)
         other_resources.map { |other_resource|
-          @ports.map {|port|
+          @ports.select(&block).map.map {|port|
             resource :aws_security_group_rule, "#{@name}-to-#{other_resource.name}-#{port[:name]}", {
                        security_group_id: self.ingress_security_group,
                        type: "ingress",

--- a/lib/terrafying/components/usable.rb
+++ b/lib/terrafying/components/usable.rb
@@ -41,21 +41,21 @@ module Terrafying
                    }
       end
 
-      def used_by_cidr(*cidrs)
-        cidrs.map { |cidr|
-          cidr_ident = cidr.gsub(/[\.\/]/, "-")
+      def used_by_cidr(*cidrs, &block)
+        cidrs.map do |cidr|
+          cidr_ident = cidr.gsub('./', '-')
 
-          @ports.map {|port|
+          @ports.select(&block).map do |port|
             resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}", {
-                       security_group_id: self.ingress_security_group,
-                       type: "ingress",
-                       from_port: from_port(port[:upstream_port]),
-                       to_port: to_port(port[:upstream_port]),
-                       protocol: port[:type] == "udp" ? "udp" : "tcp",
-                       cidr_blocks: [cidr],
-                     }
-          }
-        }
+              security_group_id: ingress_security_group,
+              type: 'ingress',
+              from_port: from_port(port[:upstream_port]),
+              to_port: to_port(port[:upstream_port]),
+              protocol: port[:type] == 'udp' ? 'udp' : 'tcp',
+              cidr_blocks: [cidr]
+            }
+          end
+        end
       end
 
       def pingable_by(*other_resources)

--- a/spec/support/shared_examples/usable.rb
+++ b/spec/support/shared_examples/usable.rb
@@ -1,4 +1,5 @@
 RSpec::Matchers.define_negated_matcher :not_include, :include
+RSpec::Matchers.define_negated_matcher :not_match, :match
 
 shared_examples "a usable resource" do
 
@@ -218,5 +219,14 @@ shared_examples "a usable resource" do
         from_port: 443, to_port: 443, cidr_blocks: ['0.0.0.0/0']
       )
     )
+  end
+
+  it 'should replace [./] with [-] in the cidr when naming the resource' do
+    @main_resource.used_by_cidr('0.0.0.0/0') { |port| port[:upstream_port] != 443 }
+
+    keys = @main_resource.output_with_children['resource']['aws_security_group_rule'].keys
+
+    expect(keys).to all(not_match('0.0.0.0/0'))
+    expect(keys).to include(a_string_matching('0-0-0-0-0'))
   end
 end

--- a/spec/support/shared_examples/usable.rb
+++ b/spec/support/shared_examples/usable.rb
@@ -1,3 +1,5 @@
+RSpec::Matchers.define_negated_matcher :not_include, :include
+
 shared_examples "a usable resource" do
 
   it { is_expected.to respond_to(:used_by) }
@@ -197,6 +199,23 @@ shared_examples "a usable resource" do
       a_hash_including(
         from_port: 1200,
         to_port:   1200
+      )
+    )
+  end
+
+  it 'should filter out ports using the block' do
+    @main_resource.used_by_cidr('0.0.0.0/0') { |port| port[:upstream_port] != 443 }
+
+    rules = @main_resource.output_with_children['resource']['aws_security_group_rule'].values
+
+    expect(rules).to include(
+      a_hash_including(
+        from_port: 80, to_port: 80, cidr_blocks: ['0.0.0.0/0']
+      )
+    )
+    expect(rules).to not_include(
+      a_hash_including(
+        from_port: 443, to_port: 443, cidr_blocks: ['0.0.0.0/0']
       )
     )
   end

--- a/spec/support/shared_examples/usable.rb
+++ b/spec/support/shared_examples/usable.rb
@@ -204,7 +204,7 @@ shared_examples "a usable resource" do
     )
   end
 
-  it 'should filter out ports using the block' do
+  it 'should filter out ports using the block when used by cidrs' do
     @main_resource.used_by_cidr('0.0.0.0/0') { |port| port[:upstream_port] != 443 }
 
     rules = @main_resource.output_with_children['resource']['aws_security_group_rule'].values
@@ -218,6 +218,24 @@ shared_examples "a usable resource" do
       a_hash_including(
         from_port: 443, to_port: 443, cidr_blocks: ['0.0.0.0/0']
       )
+    )
+  end
+
+  it 'should filter out ports using the block when used by other resources' do
+    other_resource = Terrafying::Components::Instance.create_in(@vpc, 'some-thing-else')
+    another_resource = Terrafying::Components::Instance.create_in(@vpc, 'another-thing')
+
+    resources = [other_resource, another_resource]
+
+    @main_resource.used_by(*resources) { |port| port[:upstream_port] != 443 }
+
+    rules = @main_resource.output_with_children['resource']['aws_security_group_rule'].values
+
+    expect(rules).to include(
+      *resources.map { |res| a_hash_including(from_port: 80, to_port: 80, source_security_group_id: res.egress_security_group) }
+    )
+    expect(rules).to not_include(
+      *resources.map { |res| a_hash_including(from_port: 443, to_port: 443, source_security_group_id: res.egress_security_group) }
     )
   end
 


### PR DESCRIPTION
Allow for filtering out ports on the security groups per cidr by passing a block to the method