### PR TITLE
append LetsEncrypt intermediate to CA signed certs


### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -137,7 +137,7 @@ module Terrafying
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert", {
                        bucket: @bucket,
                        key: File.join(@prefix, @name, name, "cert"),
-                       content: output_of(:acme_certificate, key_ident, :certificate_pem) + '\n' + @ca_cert,
+                       content: output_of(:acme_certificate, key_ident, :certificate_pem).to_s + '\n' + @ca_cert,
                      }
 
         reference_keypair(ctx, name)

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -69,13 +69,15 @@ module Terrafying
         @ca_cert_acl = options[:public_certificate] ? 'public-read' : 'private'
 
         open(@provider[:ca_cert], 'rb') do |cert|
-          resource :aws_s3_bucket_object, "#{@name}-cert", {
-                     bucket: @bucket,
-                     key: File.join(@prefix, @name, "ca.cert"),
-                     content: cert.read,
-                     acl: @ca_cert_acl
-                   }
+          @ca_cert = cert.read
         end
+
+        resource :aws_s3_bucket_object, "#{@name}-cert", {
+            bucket: @bucket,
+            key: File.join(@prefix, @name, "ca.cert"),
+            content: @ca_cert,
+            acl: @ca_cert_acl
+        }
 
         @source = File.join("s3://", @bucket, @prefix, @name, "ca.cert")
 
@@ -135,7 +137,7 @@ module Terrafying
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert", {
                        bucket: @bucket,
                        key: File.join(@prefix, @name, name, "cert"),
-                       content: output_of(:acme_certificate, key_ident, :certificate_pem),
+                       content: output_of(:acme_certificate, key_ident, :certificate_pem) + @ca_cert,
                      }
 
         reference_keypair(ctx, name)

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -137,7 +137,7 @@ module Terrafying
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert", {
                        bucket: @bucket,
                        key: File.join(@prefix, @name, name, "cert"),
-                       content: output_of(:acme_certificate, key_ident, :certificate_pem) + @ca_cert,
+                       content: output_of(:acme_certificate, key_ident, :certificate_pem) + '\n' + @ca_cert,
                      }
 
         reference_keypair(ctx, name)


### PR DESCRIPTION


As is, all created certs pretend to be stand-alone, which breaks the chain and makes clients not trust it. It works on browsers because they correct this [wrong] behaviour and recover by filling in the LE X3 cert, but openssl based clients won't have it. We know nginx will still happily take it as well, but others might break. We need to publish the intermediate certs to be strictly correct.
This appends the intermediate CA cert to all genned certs.

