### PR TITLE
Slice 32 chars, not 96 for block key

### DIFF
--- a/lib/terrafying/components/vpn.rb
+++ b/lib/terrafying/components/vpn.rb
@@ -81,8 +81,8 @@ module Terrafying
 
         if has_provider
           vpn_hash = Digest::SHA512.hexdigest(vpc.name + name + oauth2_provider[:client_secret] + oauth2_provider[:client_id])
-          oauth2_provider[:cookie_hash_key]  ||= vpn_hash.byteslice(0,64)
-          oauth2_provider[:cookie_block_key] ||= vpn_hash.byteslice(64,96)
+          oauth2_provider[:cookie_hash_key]  ||= vpn_hash.byteslice(0, 64)
+          oauth2_provider[:cookie_block_key] ||= vpn_hash.byteslice(64, 32)
 
           units.push(oauth2_proxy_service(oauth2_provider))
         end


### PR DESCRIPTION
byteslice takes start, length not start, end