### PR TITLE
Let caddy pass through host information

### DIFF
--- a/lib/terrafying/components/vpn.rb
+++ b/lib/terrafying/components/vpn.rb
@@ -242,12 +242,14 @@ module Terrafying
         {
           path: "/etc/caddy/Caddyfile",
           mode: "0644",
-          contents: <<EOF
-#{@fqdn}:443
-tls #{tls}
-proxy / localhost:#{port}
-EOF
-      }
+          contents: <<~CADDYFILE
+            #{@fqdn}:443
+            tls #{tls}
+            proxy / localhost:#{port} {
+              transparent
+            }
+          CADDYFILE
+        }
       end
 
       def openvpn_conf


### PR DESCRIPTION
This let's caddy set X-Forwarded-Host etc to fix OAuth redirect url.

See https://caddyserver.com/docs/proxy#presets