### PR TITLE
Use private zones when setting up an endpoint

### DIFF
--- a/lib/terrafying/components/endpointservice.rb
+++ b/lib/terrafying/components/endpointservice.rb
@@ -7,7 +7,7 @@ module Terrafying
 
     class EndpointService < Terrafying::Context
 
-      attr_reader :name, :load_balancer, :service_name
+      attr_reader :name, :load_balancer, :service_name, :fqdn, :zone
 
       def self.create_for(load_balancer, name, options={})
         EndpointService.new.create_for(load_balancer, name, options)
@@ -39,6 +39,9 @@ module Terrafying
 
         @name = name
         @load_balancer = load_balancer
+
+        @fqdn = options[:fqdn]
+        @zone = options[:zone]
 
         resource :aws_vpc_endpoint_service, name, {
                    acceptance_required: options[:acceptance_required],

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -20,7 +20,7 @@ module Terrafying
 
     class Service < Terrafying::Context
 
-      attr_reader :name, :domain_names, :ports, :instance_profile, :load_balancer, :instance_set
+      attr_reader :name, :zone, :domain_names, :ports, :instance_profile, :load_balancer, :instance_set
 
       include Usable
 
@@ -81,6 +81,7 @@ module Terrafying
         ident = "#{tf_safe(vpc.name)}-#{name}"
 
         @name = ident
+        @zone = options[:zone]
         @ports = enrich_ports(options[:ports])
         @domain_names = [ options[:zone].qualify(name) ]
 
@@ -143,7 +144,10 @@ module Terrafying
       end
 
       def with_endpoint_service(options = {})
-        add! EndpointService.create_for(@load_balancer, @name, options)
+        add! EndpointService.create_for(@load_balancer, @name, {
+                                          fqdn: @domain_names[0],
+                                          zone: @zone,
+                                        }.merge(options))
       end
 
     end


### PR DESCRIPTION
This means that we can use the same fqdn to access it across all
VPCs the service is exposed in