### PR TITLE
Default tags when finding a vpc

### DIFF
--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -34,6 +34,7 @@ module Terrafying
         @name = name
         @id = vpc.vpc_id
         @cidr = vpc.cidr_block
+        @tags = {}
         @zone = Terrafying::Components::Zone.find_by_tag({vpc: @id})
         if @zone.nil?
           raise "Failed to find zone"


### PR DESCRIPTION
In order to do peering it expects this to be a hash