### PR TITLE
Use VPC name instead of id as id's aren't available for new VPCs yet

### DIFF
--- a/lib/terrafying/components/zone.rb
+++ b/lib/terrafying/components/zone.rb
@@ -57,7 +57,7 @@ module Terrafying
         if options[:vpc]
           zone_config[:vpc_id] = options[:vpc].id
 
-          ident = tf_safe("#{options[:vpc].id}-#{ident}")
+          ident = tf_safe("#{options[:vpc].name}-#{ident}")
         end
 
         @fqdn = fqdn


### PR DESCRIPTION
When used with new VPCs this `.id` method returns a tf reference which can't be used as the name for another resource. VPC names should be unique enough for the identifier and the `zone_config[:vpc_id]` can use the tf reference correctly.

This will affect Zones created by the new vault code but those private zones shouldn't be in use yet.