### PR TITLE
Allow loadbalancer names to be specified as hexdigests

### DIFF
--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -1,3 +1,4 @@
+require 'digest'
 require 'terrafying/components/usable'
 require 'terrafying/generator'
 
@@ -62,9 +63,13 @@ module Terrafying
           ports: [],
           public: false,
           subnets: vpc.subnets.fetch(:private, []),
-          tags: {},
+          tags: {
+            Name: name
+          },
+          hex_ident: false
         }.merge(options)
 
+        @hex_ident = options[:hex_ident]
         @ports = enrich_ports(options[:ports])
 
         l4_ports = @ports.select{ |p| is_l4_port(p) }
@@ -158,7 +163,9 @@ module Terrafying
       end
 
       def make_identifier(type, vpc_name, name)
-        "#{type}-#{tf_safe(vpc_name)}-#{name}"[0..31]
+        gen_id = "#{type}-#{tf_safe(vpc_name)}-#{name}"
+        return Digest::SHA2.hexdigest(gen_id)[0..24] if @hex_ident || gen_id.size > 26
+        gen_id[0..31]
       end
 
     end

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -83,7 +83,7 @@ module Terrafying
         ident = make_identifier(@type, vpc.name, name)
         @name = ident
 
-        if @type == "application"
+        if application?
           @security_group = resource :aws_security_group, ident, {
                                        name: "loadbalancer-#{ident}",
                                        description: "Describe the ingress and egress of the load balancer #{ident}",
@@ -99,14 +99,12 @@ module Terrafying
         end
 
         @id = resource :aws_lb, ident, {
-                         name: ident,
-                         load_balancer_type: type,
-                         internal: !options[:public],
-                         subnet_mapping: options[:subnets].map{ |subnet|
-                           {subnet_id: subnet.id}
-                         },
-                         tags: options[:tags],
-                       }.merge(@type == "application" ? { security_groups: [@security_group] } : {})
+          name: ident,
+          load_balancer_type: type,
+          internal: !options[:public],
+          tags: options[:tags],
+        }.merge(subnets_for(options[:subnets]))
+         .merge(application? ? { security_groups: [@security_group] } : {})
 
         @target_groups = []
 
@@ -150,16 +148,23 @@ module Terrafying
         self
       end
 
-      def attach(set)
-        if set.respond_to?(:attach_load_balancer)
-          set.attach_load_balancer(self)
+      def application?
+        @type == 'application'
+      end
 
-          if @type == "network"
-            @security_group = set.ingress_security_group
-          end
-        else
-          raise "Dont' know how to attach object to LB"
-        end
+      def subnets_for(subnets)
+        return { subnets: subnets.map(&:id) } if application?
+        { subnet_mapping: subnets.map { |subnet| { subnet_id: subnet.id } } }
+      end
+
+      def network?
+        @type == 'network'
+      end
+
+      def attach(set)
+        raise "Dont' know how to attach object to LB" unless set.respond_to?(:attach_load_balancer)
+        set.attach_load_balancer(self)
+        @security_group = set.ingress_security_group if network?
       end
 
       def make_identifier(type, vpc_name, name)
@@ -167,9 +172,6 @@ module Terrafying
         return Digest::SHA2.hexdigest(gen_id)[0..24] if @hex_ident || gen_id.size > 26
         gen_id[0..31]
       end
-
     end
-
   end
-
 end

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
+require 'digest'
 require 'terrafying'
 require 'terrafying/components/instance'
 require 'terrafying/components/loadbalancer'
 require 'terrafying/components/staticset'
-
 
 RSpec.describe Terrafying::Components::LoadBalancer do
 
@@ -91,6 +93,17 @@ RSpec.describe Terrafying::Components::LoadBalancer do
       @vpc, "abcdefghijklmnopqrstuvwxyz123456789", {}
     )
     expect(lb.name.length).to be <= 32
+  end
+
+  it 'should use hex identifiers when requested' do
+    name = 'abcdefghijklmnopqrstuvwxyz123456789'
+    expected_hex = Digest::SHA2.hexdigest("application-#{@vpc.name}-#{name}")[0..24]
+
+    lb = Terrafying::Components::LoadBalancer.create_in(
+      @vpc, name, hex_ident: true
+    )
+
+    expect(lb.name).to eq(expected_hex)
   end
 
 end


### PR DESCRIPTION
This prevents overrunning the 32 char limit on lb and target groups.
The LB name will still be stored in the Name tag

Either as a specific opt in `hex_ident: true` or if your LB name would be over 26 chars.