### PR TITLE
Use X-Forwarded-Email header for OpenVPN cert CNs

### DIFF
--- a/lib/terrafying/components/vpn.rb
+++ b/lib/terrafying/components/vpn.rb
@@ -161,6 +161,7 @@ module Terrafying
             arguments: optional_arguments + [
               "--fqdn #{@fqdn}",
               "--cache /var/openvpn-authz",
+              '--user-header "X-Forwarded-Email"',
               "/etc/ssl/openvpn",
             ],
           }


### PR DESCRIPTION
This configures the `openvpn-authz` service to use the `X-Forwarded-Email` header set by the Authnz proxy to identify clients to OpenVPN.

Previously certs were issued with CN = Remote address which was translated to a IPv6 local address and port as this is called from the Authnz proxy. This means that clients can be issued duplicate certs which results in OpenVPN kicking random clients as new ones with duplicate CNs connect.