### PR TITLE
Use version tag for OpenVPN authz

### DIFF
--- a/lib/terrafying/components/vpn.rb
+++ b/lib/terrafying/components/vpn.rb
@@ -148,7 +148,7 @@ module Terrafying
         end
 
         Ignition.container_unit(
-          "openvpn-authz", "quay.io/uswitch/openvpn-authz:stable",
+          "openvpn-authz", "quay.io/uswitch/openvpn-authz:1.1",
           {
             host_networking: true,
             volumes: [


### PR DESCRIPTION
The switches the openvpn-authz container to use a versioned tag rather than "stable".

We're also switching to the lastest version of openvpn-authz.