### PR TITLE
ALB multiple certs

### DIFF
--- a/spec/terrafying/components/ignition_spec.rb
+++ b/spec/terrafying/components/ignition_spec.rb
@@ -6,6 +6,13 @@ require 'terrafying/util'
 
 
 RSpec.describe Terrafying::Components::Ignition, '#container_unit' do
+  before do
+    @aws = double('AWS')
+    allow(@aws).to receive(:region).and_return('eu-west-1')
+    allow_any_instance_of(Terrafying::Context).to receive(:aws).and_return(@aws)
+  end
+
+
   it 'creates a unit file' do
     container_unit = Terrafying::Components::Ignition.container_unit("app", "app:latest")
 
@@ -69,6 +76,12 @@ RSpec.describe Terrafying::Components::Ignition, '#container_unit' do
 end
 
 RSpec.describe Terrafying::Components::Ignition, '#generate' do
+  before do
+    @aws = double('AWS')
+    allow(@aws).to receive(:region).and_return('eu-west-1')
+    allow_any_instance_of(Terrafying::Context).to receive(:aws).and_return(@aws)
+  end
+
   context 'with volumes' do
     it 'creates userdata with correct mountpoints' do
       options = {


### PR DESCRIPTION
This adds support for multiple SSL certs per ALB with the [aws_lb_listener_certificate](https://www.terraform.io/docs/providers/aws/r/lb_listener_certificate.html) resource.

Additionally is fixes an issue where passing any tags would cause the Name tag to be removed.