### PR TITLE
Autoscaling policy doesn't need to set adjustment type

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -153,7 +153,6 @@ module Terrafying
           resource :aws_autoscaling_policy, policy_name, {
             name: policy_name,
             autoscaling_group_name: @asg,
-            adjustment_type: 'ChangeInCapacity',
             policy_type: 'TargetTrackingScaling',
             target_tracking_configuration: {
               predefined_metric_specification: {


### PR DESCRIPTION
This TargetTrackingScaling policy doesn't need to set adjustment type. If it is set then Terraform will attempt to change the policy on every apply.

```
~ aws_autoscaling_policy.5b0ad3dc25733e95250235233-Main-envoy-internal-route53-wildcard-entries-node-0
    adjustment_type: "" => "ChangeInCapacity"
```