### PR TITLE
Allow Loadbalancer ports to specify actions

### DIFF
--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -119,12 +119,7 @@ module Terrafying
         @ports.each { |port|
           port_ident = "#{ident}-#{port[:downstream_port]}"
 
-          target_group = resource :aws_lb_target_group, port_ident, {
-                                    name: port_ident,
-                                    port: port[:downstream_port],
-                                    protocol: port[:type].upcase,
-                                    vpc_id: vpc.id,
-                                  }.merge(port.has_key?(:health_check) ? { health_check: port[:health_check] }: {})
+          default_action = port.key?(:action) ? port[:action] : forward_to_tg(port, port_ident, vpc)
 
           ssl_options = alb_certs(port, port_ident)
 
@@ -132,16 +127,11 @@ module Terrafying
                      load_balancer_arn: @id,
                      port: port[:upstream_port],
                      protocol: port[:type].upcase,
-                     default_action: {
-                       target_group_arn: target_group,
-                       type: "forward",
-                     },
+                     default_action: default_action,
                    }.merge(ssl_options)
 
-          @targets << Struct::Target.new(
-            target_group: target_group,
-            listener: listener
-          )
+          redirect_http(port[:redirect_http_from_port], port[:upstream_port], ident) if port.key?(:redirect_http_from_port)
+          register_target(default_action[:target_group_arn], listener) if default_action[:type] == 'forward'
         }
 
         @alias_config = {
@@ -149,8 +139,44 @@ module Terrafying
           zone_id: output_of(:aws_lb, ident, :zone_id),
           evaluate_target_health: true,
         }
-
         self
+      end
+
+      def redirect_http(from_port, to_port, ident)
+        resource :aws_lb_listener, "#{ident}-#{from_port}", {
+          load_balancer_arn: @id,
+          port: from_port,
+          protocol: 'http',
+          default_action: {
+            type: 'redirect',
+            redirect: {
+              port: to_port,
+              protocol: 'HTTPS',
+              status_code: 'HTTP_301'
+            }
+          }
+        }
+      end
+
+      def forward_to_tg(port, port_ident, vpc)
+        target_group = resource :aws_lb_target_group, port_ident, {
+          name: port_ident,
+          port: port[:downstream_port],
+          protocol: port[:type].upcase,
+          vpc_id: vpc.id,
+        }.merge(port.has_key?(:health_check) ? { health_check: port[:health_check] }: {})
+
+        {
+          type: 'forward',
+          target_group_arn: target_group
+        }
+      end
+
+      def register_target(target_group, listener)
+        @targets << Struct::Target.new(
+          target_group: target_group,
+          listener: listener
+        )
       end
 
       def alb_certs(port, port_ident)

--- a/lib/terrafying/components/ports.rb
+++ b/lib/terrafying/components/ports.rb
@@ -7,23 +7,54 @@ PORT_NAMES = {
 }
 
 def enrich_ports(ports)
-  ports.map { |port|
+  ports = add_upstream_downstream(ports)
+  ports = add_redirects(ports)
+  add_names(ports)
+end
+
+def add_upstream_downstream(ports)
+  ports.map do |port|
     if port.is_a?(Numeric)
       port = { upstream_port: port, downstream_port: port }
     end
 
-    if port.has_key?(:number)
+    if port.key?(:number)
       port[:upstream_port] = port[:number]
       port[:downstream_port] = port[:number]
     end
+    port
+  end
+end
 
-    port = {
-      type: "tcp",
+def add_redirects(ports)
+  ports.flat_map do |port|
+    if port.key? :redirect_http_from_port
+      redirect_port = redirect_http(port[:redirect_http_from_port], port[:upstream_port])
+      port.delete(:redirect_http_from_port)
+      return [port, redirect_port]
+    end
+    port
+  end
+end
+
+def redirect_http(from_port, to_port)
+  {
+    upstream_port: from_port,
+    downstream_port: from_port,
+    action: {
+      type: 'redirect',
+      redirect: { port: to_port, protocol: 'HTTPS', status_code: 'HTTP_301' }
+    }
+  }
+end
+
+def add_names(ports)
+  ports.map do |port|
+    {
+      type: 'tcp',
       name: PORT_NAMES.fetch(port[:upstream_port], port[:upstream_port].to_s),
     }.merge(port)
-
-    port
-  }
+  end
 end
 
 def from_port(port)

--- a/lib/terrafying/components/ports.rb
+++ b/lib/terrafying/components/ports.rb
@@ -41,6 +41,7 @@ def redirect_http(from_port, to_port)
   {
     upstream_port: from_port,
     downstream_port: from_port,
+    type: 'http',
     action: {
       type: 'redirect',
       redirect: { port: to_port, protocol: 'HTTPS', status_code: 'HTTP_301' }

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -6,6 +6,8 @@ require 'terrafying/components/instance'
 require 'terrafying/components/loadbalancer'
 require 'terrafying/components/staticset'
 
+RSpec::Matchers.define_negated_matcher :not_include, :include
+
 RSpec.describe Terrafying::Components::LoadBalancer do
 
   it_behaves_like "a usable resource"
@@ -161,7 +163,87 @@ RSpec.describe Terrafying::Components::LoadBalancer do
         )
       end
     end
+  end
 
+  context('adding targets to the loadbalancer') do
+    it('should create a listener for each port') do
+      lb = Terrafying::Components::LoadBalancer.create_in(
+        @vpc, 'test-alb', ports: [
+          { type: 'http',  number: 80 },
+          { type: 'https', number: 443 }
+        ]
+      )
+
+      listeners = lb.output_with_children['resource']['aws_lb_listener'].values
+
+      expect(listeners).to include(
+        a_hash_including(port: 80,  protocol: 'HTTP'),
+        a_hash_including(port: 443, protocol: 'HTTPS')
+      )
+    end
+
+    it('should create a target group a port with no action') do
+      lb = Terrafying::Components::LoadBalancer.create_in(
+        @vpc, 'test-alb', ports: [{ type: 'http', number: 80 }]
+      )
+
+      target_group = lb.output_with_children['resource']['aws_lb_target_group'].values.first
+
+      expect(target_group).to include(port: 80, protocol: 'HTTP')
+    end
+
+    it('should create a listener with a forward action for a port by default') do
+      lb = Terrafying::Components::LoadBalancer.create_in(
+        @vpc, 'test-alb', ports: [{ type: 'http', number: 80 }]
+      )
+
+      listener = lb.output_with_children['resource']['aws_lb_listener'].values.first
+
+      expect(listener).to include(
+        port: 80,
+        default_action: a_hash_including(
+          type: 'forward',
+          target_group_arn: '${aws_lb_target_group.application-a-vpc-test-alb-80.id}'
+        )
+      )
+    end
+
+    it('should create a listener with with an action for a port an action specified') do
+      lb = Terrafying::Components::LoadBalancer.create_in(
+        @vpc, 'test-alb', ports: [{
+          type: 'http', number: 80, action: { type: 'redirect', redirect: {} }
+        }]
+      )
+
+      listener = lb.output_with_children['resource']['aws_lb_listener'].values.first
+
+      expect(listener).to include(
+        port: 80,
+        default_action: { type: 'redirect', redirect: {} }
+      )
+    end
+
+    it('should only register a target for each port with no actions specified') do
+      lb = Terrafying::Components::LoadBalancer.create_in(
+        @vpc, 'test-alb', ports: [
+          { type: 'http',  number: 80 },
+          { type: 'https', number: 443 },
+          { type: 'https', number: 4433, action: { type: 'redirect', redirect: {} } },
+        ]
+      )
+
+      expect(lb.targets.size).to eq(2)
+      expect(lb.targets).to include(
+        have_attributes(
+          listener:     '${aws_lb_listener.application-a-vpc-test-alb-80.id}',
+          target_group: '${aws_lb_target_group.application-a-vpc-test-alb-80.id}'
+        ),
+        have_attributes(
+          listener:     '${aws_lb_listener.application-a-vpc-test-alb-443.id}',
+          target_group: '${aws_lb_target_group.application-a-vpc-test-alb-443.id}'
+        )
+      )
+    end
   end
 
   context('network load balancer') do

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Terrafying::Components::LoadBalancer do
       )
 
       expect(lb.targets.size).to eq(2)
-      expect(lb.targets).to include(
+      expect(lb.targets).to contain_exactly(
         have_attributes(
           listener:     '${aws_lb_listener.application-a-vpc-test-alb-80.id}',
           target_group: '${aws_lb_target_group.application-a-vpc-test-alb-80.id}'

--- a/spec/terrafying/components/ports_spec.rb
+++ b/spec/terrafying/components/ports_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'terrafying/components/ports'
+
+RSpec.describe Object, '#enrich_ports' do
+  context 'when http redirect is specified' do
+    it 'should create a new http port' do
+      ports = [{
+        number: 443,
+        redirect_http_from_port: 80
+      }]
+
+      enriched_ports = enrich_ports(ports)
+
+      expect(enriched_ports).to include(
+        a_hash_including(name: 'http', upstream_port: 80, downstream_port: 80)
+      )
+    end
+
+    it 'should create a http redirect action' do
+      ports = [{
+        number: 443,
+        redirect_http_from_port: 80
+      }]
+
+      enriched_ports = enrich_ports(ports)
+
+      expect(enriched_ports).to include(
+        a_hash_including(
+          name: 'http',
+          action: {
+            type: 'redirect',
+            redirect: {
+              port: 443,
+              protocol: 'HTTPS',
+              status_code: 'HTTP_301'
+            }
+          }
+        )
+      )
+    end
+  end
+
+  context 'converting to port' do
+    it 'should convert a number to a port' do
+      ports = [123]
+
+      enriched_ports = enrich_ports(ports)
+
+      expect(enriched_ports).to include(
+        a_hash_including(name: '123', upstream_port: 123, downstream_port: 123)
+      )
+    end
+
+    it 'should convert a hash with a number to a port' do
+      ports = [{ number: 123 }]
+
+      enriched_ports = enrich_ports(ports)
+
+      expect(enriched_ports).to include(
+        a_hash_including(name: '123', upstream_port: 123, downstream_port: 123)
+      )
+    end
+  end
+
+
+  context 'port names' do
+    it 'should name the port according to the IANA number' do
+      ports = [22, 80, 443, 1194]
+
+      enriched_ports = enrich_ports(ports)
+
+      expect(enriched_ports).to include(
+        a_hash_including(name: 'ssh', upstream_port: 22),
+        a_hash_including(name: 'http', upstream_port: 80),
+        a_hash_including(name: 'https', upstream_port: 443),
+        a_hash_including(name: 'openvpn', upstream_port: 1194)
+      )
+    end
+  end
+end

--- a/spec/terrafying/components/ports_spec.rb
+++ b/spec/terrafying/components/ports_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Object, '#enrich_ports' do
   context 'when http redirect is specified' do
     it 'should create a new http port' do
       ports = [{
+        type: 'https',
         number: 443,
         redirect_http_from_port: 80
       }]
@@ -13,7 +14,12 @@ RSpec.describe Object, '#enrich_ports' do
       enriched_ports = enrich_ports(ports)
 
       expect(enriched_ports).to include(
-        a_hash_including(name: 'http', upstream_port: 80, downstream_port: 80)
+        a_hash_including(
+          name: 'http',
+          type: 'http',
+          upstream_port: 80,
+          downstream_port: 80,
+        )
       )
     end
 


### PR DESCRIPTION
This allows services using loadbalancers to specify actions instead of always getting a 'forward' action. 

Additionally it can create a HTTP -> HTTPS redirect to a given port with the 'redirect_http_from_port' option. This allows clients to request redirection in a simple way, or, if more complicated patterns are needed, specify their own actions directly.