### PR TITLE
Use aws_security_group_rule for default egress rules.

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -53,19 +53,13 @@ module Terrafying
         @ports = enrich_ports(options[:ports])
 
         @security_group = resource :aws_security_group, ident, {
-                                     name: "dynamicset-#{ident}",
-                                     description: "Describe the ingress and egress of the service #{ident}",
-                                     tags: options[:tags],
-                                     vpc_id: vpc.id,
-                                     egress: [
-                                       {
-                                         from_port: 0,
-                                         to_port: 0,
-                                         protocol: -1,
-                                         cidr_blocks: ["0.0.0.0/0"],
-                                       }
-                                     ],
-                                   }
+          name: "dynamicset-#{ident}",
+          description: "Describe the ingress and egress of the service #{ident}",
+          tags: options[:tags],
+          vpc_id: vpc.id
+        }
+
+        default_egress_rule(ident, @security_group)
 
         path_mtu_setup!
 
@@ -121,6 +115,18 @@ module Terrafying
         @asg = output_of(:aws_cloudformation_stack, ident, 'outputs["AsgName"]')
 
         self
+      end
+
+
+      def default_egress_rule(ident, security_group)
+        resource :aws_security_group_rule, "#{ident}-default-egress", {
+          security_group_id: security_group,
+          type: 'egress',
+          from_port: 0,
+          to_port: 0,
+          protocol: -1,
+          cidr_blocks: ['0.0.0.0/0'],
+        }
       end
 
       def profile_from(profile)

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -59,19 +59,13 @@ module Terrafying
         @ports = enrich_ports(options[:ports])
 
         @security_group = resource :aws_security_group, ident, {
-                                     name: "staticset-#{ident}",
-                                     description: "Describe the ingress and egress of the static set #{ident}",
-                                     tags: options[:tags],
-                                     vpc_id: vpc.id,
-                                     egress: [
-                                       {
-                                         from_port: 0,
-                                         to_port: 0,
-                                         protocol: -1,
-                                         cidr_blocks: ["0.0.0.0/0"],
-                                       }
-                                     ],
-                                   }
+          name: "staticset-#{ident}",
+          description: "Describe the ingress and egress of the static set #{ident}",
+          tags: options[:tags],
+          vpc_id: vpc.id,
+        }
+
+        default_egress_rule(ident, @security_group)
 
         path_mtu_setup!
 
@@ -111,6 +105,17 @@ module Terrafying
         }
 
         self
+      end
+
+      def default_egress_rule(ident, security_group)
+        resource :aws_security_group_rule, "#{ident}-default-egress", {
+          security_group_id: security_group,
+          type: 'egress',
+          from_port: 0,
+          to_port: 0,
+          protocol: -1,
+          cidr_blocks: ['0.0.0.0/0'],
+        }
       end
 
       def volume_for(name, instance, volume, tags)

--- a/spec/support/shared_examples/usable.rb
+++ b/spec/support/shared_examples/usable.rb
@@ -1,3 +1,5 @@
+require 'terrafying/components/instance'
+
 RSpec::Matchers.define_negated_matcher :not_include, :include
 RSpec::Matchers.define_negated_matcher :not_match, :match
 

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe Terrafying::Components::Service do
     end
 
     context('metrics ports') do
-      it 'should use the specified instance profile' do
+      it 'should allow the prom security group to connect to the metric ports' do
         port = 1234
         prom_sec_group = 'sg-1234567890'
         allow(@vpc.aws).to receive(:security_group_in_vpc).and_return(prom_sec_group)

--- a/spec/terrafying/components/staticset_spec.rb
+++ b/spec/terrafying/components/staticset_spec.rb
@@ -105,4 +105,30 @@ RSpec.describe Terrafying::Components::StaticSet do
     expect(port_rules.all? {|r| r[:self]}).to be true
   end
 
+  context 'security_groups' do
+    it 'should define no rules directly on the egress group' do
+      set = described_class.create_in(@vpc, "foo")
+
+      rules = set.output['resource']['aws_security_group']['a-vpc-foo']
+
+      expect(rules.keys).to not_include(:egress, :ingress)
+    end
+
+    it 'should add a default egress rule to 0.0.0.0/0' do
+      set = described_class.create_in(@vpc, "foo")
+
+      rules = set.output['resource']['aws_security_group_rule'].values
+
+      expect(rules).to include(
+        a_hash_including(
+          security_group_id: set.egress_security_group,
+          type: 'egress',
+          from_port: 0,
+          to_port: 0,
+          protocol: -1,
+          cidr_blocks: ['0.0.0.0/0'],
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
This should stop terraform from flip-flopping when egress rules are defined