### PR TITLE
Allow idle timeout to be set on ALBs

### DIFF
--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -70,6 +70,7 @@ module Terrafying
           public: false,
           subnets: vpc.subnets.fetch(:private, []),
           hex_ident: false,
+          idle_timeout: nil,
           tags: {}
         }.merge(options)
 
@@ -112,7 +113,8 @@ module Terrafying
           internal: !options[:public],
           tags: @tags,
         }.merge(subnets_for(options[:subnets]))
-         .merge(application? ? { security_groups: [@security_group] } : {})
+         .merge(application? ? { security_groups: [@security_group], idle_timeout: options[:idle_timeout] } : {})
+         .compact
 
         @targets = []
 


### PR DESCRIPTION
The default ALB idle timeout value of 60s is insufficient for some teams so we'll need to be able to set it. For now setting it directly on the LB is enough as it's only going to be used by the Envoy Ingress ALBs.