### PR TITLE
Fix cycles when creating a signalling dynamic set

### DIFF
--- a/lib/terrafying/components/instanceprofile.rb
+++ b/lib/terrafying/components/instanceprofile.rb
@@ -5,7 +5,7 @@ module Terrafying
 
     class InstanceProfile < Terrafying::Context
 
-      attr_reader :id, :role_arn, :role_resource
+      attr_reader :id, :resource_name, :role_arn, :role_resource
 
       def self.create(name, options={})
         InstanceProfile.new.create name, options
@@ -49,6 +49,7 @@ module Terrafying
                          role: output_of(:aws_iam_role, name, :name),
                        }
         @name = name
+        @resource_name = "aws_iam_instance_profile.#{name}"
 
         @role_arn = output_of(:aws_iam_role, name, :arn)
         @role_resource = "aws_iam_role.#{name}"

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -154,7 +154,7 @@ module Terrafying
             {
               Effect: "Allow",
               Action: [ "cloudformation:SignalResource" ],
-              Resource: [ @instance_set.stack_arn ],
+              Resource: [ @instance_set.stack ],
             }
           )
         end

--- a/spec/terrafying/components/dynamicset_spec.rb
+++ b/spec/terrafying/components/dynamicset_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Terrafying::Components::DynamicSet do
 
     launch_config = output["resource"]["aws_launch_configuration"].values.first
 
-    expect(launch_config[:depends_on]).to include(*instance_profile.resource_names)
+    expect(launch_config[:depends_on]).to include(instance_profile.resource_name)
   end
 
   it "should not set update policy if rollig_update is false" do

--- a/spec/terrafying/components/service_spec.rb
+++ b/spec/terrafying/components/service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Terrafying::Components::Service do
                                             {
                                               Effect: 'Allow',
                                               Action: ['cloudformation:SignalResource'],
-                                              Resource: [service.instance_set.stack_arn.to_s],
+                                              Resource: [service.instance_set.stack.to_s],
                                             }
                                           )
                                         )
@@ -55,7 +55,7 @@ RSpec.describe Terrafying::Components::Service do
                                                 {
                                                   Effect: 'Allow',
                                                   Action: ['cloudformation:SignalResource'],
-                                                  Resource: [service.instance_set.stack_arn.to_s],
+                                                  Resource: [service.instance_set.stack.to_s],
                                                 }
                                               )
                                             )


### PR DESCRIPTION
Because the launch config used to depend on all of the resources in
an instance profile context it would create a cycle when the cfn
iam statement was referencing the id of the cfn stack in order to
give it signalling permission.

This also tidies up the use of stack.arn for .id, as .arn doesn't
exist