### PR TITLE
Use sha256 for LE keys

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -64,7 +64,7 @@ module Terrafying
 
         resource :aws_s3_bucket_object, "#{@name}-account", {
           bucket: @bucket,
-          key: File.join(@prefix, @name, "account.key"),
+          key: File.join('', @prefix, @name, "account.key"),
           content: @account_key,
         }
 
@@ -76,7 +76,7 @@ module Terrafying
 
         resource :aws_s3_bucket_object, "#{@name}-cert", {
           bucket: @bucket,
-          key: File.join(@prefix, @name, "ca.cert"),
+          key: File.join('', @prefix, @name, "ca.cert"),
           content: @ca_cert,
           acl: @ca_cert_acl
         }
@@ -132,13 +132,13 @@ module Terrafying
 
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-key", {
                        bucket: @bucket,
-                       key: File.join(@prefix, @name, name, "key"),
+                       key: File.join('', @prefix, @name, name, "${sha256(tls_private_key.#{key_ident}.private_key_pem)}", "key"),
                        content: output_of(:tls_private_key, key_ident, :private_key_pem),
                      }
 
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert", {
                        bucket: @bucket,
-                       key: File.join(@prefix, @name, name, "cert"),
+                       key: File.join('', @prefix, @name, name, "${sha256(acme_certificate.#{key_ident}.certificate_pem)}", "cert"),
                        content: output_of(:acme_certificate, key_ident, :certificate_pem).to_s + @ca_cert,
                      }
 

--- a/lib/terrafying/components/selfsignedca.rb
+++ b/lib/terrafying/components/selfsignedca.rb
@@ -48,7 +48,7 @@ module Terrafying
           @ca_cert = options[:ca_cert]
           resource :aws_s3_bucket_object, "#{@name}-cert", {
                      bucket: @bucket,
-                     key: File.join(@prefix, @name, "ca.cert"),
+                     key: File.join('', @prefix, @name, "ca.cert"),
                      content: @ca_cert,
                      acl: cert_acl,
                    }
@@ -82,7 +82,7 @@ module Terrafying
 
         resource :aws_s3_bucket_object, "#{@name}-cert", {
                    bucket: @bucket,
-                   key: File.join(@prefix, @name, "ca.cert"),
+                   key: File.join('', @prefix, @name, "ca.cert"),
                    content: @ca_cert,
                    acl: cert_acl,
                  }
@@ -93,7 +93,7 @@ module Terrafying
       def keypair
         @ca_key_ref ||= resource :aws_s3_bucket_object, "#{@name}-key", {
                                    bucket: @bucket,
-                                   key: File.join(@prefix, @name, "ca.key"),
+                                   key: File.join('', @prefix, @name, "ca.key"),
                                    content: @ca_key,
                                  }
 
@@ -169,13 +169,13 @@ module Terrafying
 
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-key", {
                        bucket: @bucket,
-                       key: File.join(@prefix, @name, name, "${sha256(tls_private_key.#{key_ident}.private_key_pem)}", "key"),
+                       key: File.join('', @prefix, @name, name, "${sha256(tls_private_key.#{key_ident}.private_key_pem)}", "key"),
                        content: output_of(:tls_private_key, key_ident, :private_key_pem),
                      }
 
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert", {
                        bucket: @bucket,
-                       key: File.join(@prefix, @name, name, "${sha256(tls_locally_signed_cert.#{key_ident}.cert_pem)}", "cert"),
+                       key: File.join('', @prefix, @name, name, "${sha256(tls_locally_signed_cert.#{key_ident}.cert_pem)}", "cert"),
                        content: output_of(:tls_locally_signed_cert, key_ident, :cert_pem),
                      }
 

--- a/spec/support/shared_examples/ca.rb
+++ b/spec/support/shared_examples/ca.rb
@@ -50,8 +50,21 @@ shared_examples "a CA" do
         expect(ca_cert.count).to eq(1)
         expect(ca_cert[0][:acl]).to eq("public-read")
       end
-  end
+    end
 
+    it 'should have keys/certs that start with "/" when it has no prefix' do
+      ca = described_class.create(ca_name, bucket_name)
+      s3_objects = ca.output['resource']['aws_s3_bucket_object'].values
+
+      expect(s3_objects).to all(include(key: start_with('/')))
+    end
+ 
+    it 'should have keys/certs that start with "/" when it has a prefix' do
+      ca = described_class.create(ca_name, bucket_name, prefix: 'a_prefix')
+      s3_objects = ca.output['resource']['aws_s3_bucket_object'].values
+
+      expect(s3_objects).to all(include(key: start_with('/')))
+    end
   end
 
   describe ".create_keypair_in" do
@@ -97,6 +110,23 @@ shared_examples "a CA" do
       }).to be true
     end
 
+    it 'should have keys/certs that start with "/" when it has no prefix' do
+      ca = described_class.create(ca_name, bucket_name)
+      ca.create_keypair('bar')
+
+      s3_objects = ca.output['resource']['aws_s3_bucket_object'].values
+
+      expect(s3_objects).to all(include(key: start_with('/')))
+    end
+
+    it 'should have keys/certs that start with "/" when it has a prefix' do
+      ca = described_class.create(ca_name, bucket_name, prefix: 'a_prefix')
+      ca.create_keypair('bar')
+
+      s3_objects = ca.output['resource']['aws_s3_bucket_object'].values
+
+      expect(s3_objects).to all(include(key: start_with('/')))
+    end
   end
 
   it "should be sortable" do


### PR DESCRIPTION
This also ensures all s3 certs/keys are prefixed with '/' so that paths can be constructed using TF interpolation.