### PR TITLE
Suspend Autoscaling processes while doing CloudFormation rolling updates

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -228,6 +228,7 @@ module Terrafying
               MaxBatchSize: "#{instances[:desired]}",
               PauseTime: "PT10M",
               WaitOnResourceSignals: true,
+              SuspendProcesses: %w[HealthCheck ReplaceUnhealthy AZRebalance AlarmNotification ScheduledActions],
             }
           }
         elsif rolling_update
@@ -235,7 +236,8 @@ module Terrafying
             AutoScalingRollingUpdate: {
               MinInstancesInService: "#{instances[:min]}",
               MaxBatchSize: "1",
-              PauseTime: "PT0S"
+              PauseTime: "PT0S",
+              SuspendProcesses: %w[HealthCheck ReplaceUnhealthy AZRebalance AlarmNotification ScheduledActions],
             }
           }
         end

--- a/spec/terrafying/components/dynamicset_spec.rb
+++ b/spec/terrafying/components/dynamicset_spec.rb
@@ -30,42 +30,76 @@ RSpec.describe Terrafying::Components::DynamicSet do
     expect(launch_config[:depends_on]).to include(instance_profile.resource_name)
   end
 
-  it "should not set update policy if rollig_update is false" do
-    dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", { rolling_update: false })
-    output = dynamic_set.output_with_children
-    template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body])
-    expect(template_body["Resources"]["AutoScalingGroup"]["UpdatePolicy"]).to be_nil
-  end
+  context 'cloudformation template' do
+    it "should not set update policy if rollig_update is false" do
+      dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", { rolling_update: false })
+      output = dynamic_set.output_with_children
+      template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body])
+      expect(template_body["Resources"]["AutoScalingGroup"]["UpdatePolicy"]).to be_nil
+    end
 
-  it "should set update policy by default" do
-    dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", )
-    output = dynamic_set.output_with_children
-    template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body])
-    expect(template_body["Resources"]["AutoScalingGroup"]["UpdatePolicy"]["AutoScalingRollingUpdate"]).not_to be_nil
-    expect(template_body["Resources"]["AutoScalingGroup"]["UpdatePolicy"]["AutoScalingRollingUpdate"]["WaitOnResourceSignals"]).to be_falsey
-  end
+    it "should set update policy by default" do
+      dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", )
+      output = dynamic_set.output_with_children
+      template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body])
+      expect(template_body["Resources"]["AutoScalingGroup"]["UpdatePolicy"]["AutoScalingRollingUpdate"]).not_to be_nil
+      expect(template_body["Resources"]["AutoScalingGroup"]["UpdatePolicy"]["AutoScalingRollingUpdate"]["WaitOnResourceSignals"]).to be_falsey
+    end
 
-  it "should expect a signal when configured" do
-    dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", { rolling_update: :signal })
+    it 'should suspend asg processes while doing a rolling update by default' do
+      dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", )
 
-    output = dynamic_set.output_with_children
-    template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body])
+      output = dynamic_set.output_with_children
+      template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body], symbolize_names: true)
+      update_policy = template_body[:Resources][:AutoScalingGroup][:UpdatePolicy]
 
-    expect(template_body["Resources"]["AutoScalingGroup"]["UpdatePolicy"]["AutoScalingRollingUpdate"]["WaitOnResourceSignals"]).to be true
-  end
+      expect(update_policy).to include(
+        AutoScalingRollingUpdate: a_hash_including(
+          SuspendProcesses: a_collection_including(
+            'HealthCheck', 'ReplaceUnhealthy', 'AZRebalance', 'AlarmNotification', 'ScheduledActions'
+          )
+        )
+      )
+    end
 
-  it "should track what the ASG is configured as" do
-    asg = Aws::AutoScaling::Types::AutoScalingGroup.new(min_size: 3, max_size: 10, desired_capacity: 6)
-    allow(@aws).to receive(:asgs_by_tags).and_return([asg])
+    it 'should suspend asg processes while doing a rolling update with a signal' do
+      dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", rolling_update: :signal)
 
-    dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", { instances: { min: 1, max: 1, desired: 1, track: true, tags: {} } })
+      output = dynamic_set.output_with_children
+      template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body], symbolize_names: true)
+      update_policy = template_body[:Resources][:AutoScalingGroup][:UpdatePolicy]
 
-    output = dynamic_set.output_with_children
-    template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body])
+      expect(update_policy).to include(
+        AutoScalingRollingUpdate: a_hash_including(
+          SuspendProcesses: a_collection_including(
+            'HealthCheck', 'ReplaceUnhealthy', 'AZRebalance', 'AlarmNotification', 'ScheduledActions'
+          )
+        )
+      )
+    end
 
-    expect(template_body["Resources"]["AutoScalingGroup"]["Properties"]["MaxSize"]).to eq(asg.max_size.to_s)
-    expect(template_body["Resources"]["AutoScalingGroup"]["Properties"]["MinSize"]).to eq(asg.min_size.to_s)
-    expect(template_body["Resources"]["AutoScalingGroup"]["Properties"]["DesiredCapacity"]).to eq(asg.desired_capacity.to_s)
+    it "should expect a signal when configured" do
+      dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", { rolling_update: :signal })
+
+      output = dynamic_set.output_with_children
+      template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body])
+
+      expect(template_body["Resources"]["AutoScalingGroup"]["UpdatePolicy"]["AutoScalingRollingUpdate"]["WaitOnResourceSignals"]).to be true
+    end
+
+    it "should track what the ASG is configured as" do
+      asg = Aws::AutoScaling::Types::AutoScalingGroup.new(min_size: 3, max_size: 10, desired_capacity: 6)
+      allow(@aws).to receive(:asgs_by_tags).and_return([asg])
+
+      dynamic_set = Terrafying::Components::DynamicSet.create_in(@vpc, "foo", { instances: { min: 1, max: 1, desired: 1, track: true, tags: {} } })
+
+      output = dynamic_set.output_with_children
+      template_body = JSON.parse(output["resource"]["aws_cloudformation_stack"].values.first[:template_body])
+
+      expect(template_body["Resources"]["AutoScalingGroup"]["Properties"]["MaxSize"]).to eq(asg.max_size.to_s)
+      expect(template_body["Resources"]["AutoScalingGroup"]["Properties"]["MinSize"]).to eq(asg.min_size.to_s)
+      expect(template_body["Resources"]["AutoScalingGroup"]["Properties"]["DesiredCapacity"]).to eq(asg.desired_capacity.to_s)
+    end
   end
 
   context 'security_groups' do


### PR DESCRIPTION
To avoid issues with CloudFormation rolling updates we'll suspend some ASG processes during updates.

Ref: 
https://aws.amazon.com/premiumsupport/knowledge-center/auto-scaling-group-rolling-updates/
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html
https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_SuspendProcesses.html