### PR TITLE
Switch to using the 'subnets' property

### DIFF
--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -191,8 +191,7 @@ module Terrafying
       end
 
       def subnets_for(subnets)
-        return { subnets: subnets.map(&:id) } if application?
-        { subnet_mapping: subnets.map { |subnet| { subnet_id: subnet.id } } }
+        return { subnets: subnets.map(&:id) }
       end
 
       def network?

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -271,7 +271,7 @@ RSpec.describe Terrafying::Components::LoadBalancer do
   end
 
   context('network load balancer') do
-    it('should use subnet_mapping to specify the list of subnets') do
+    it('should use subnets to specify the list of subnets') do
       lb = Terrafying::Components::LoadBalancer.create_in(
         @vpc, 'test-alb', ports: [{ type: 'tcp', number: 22 }]
       )
@@ -279,10 +279,10 @@ RSpec.describe Terrafying::Components::LoadBalancer do
       lb_resource = lb.output_with_children['resource']['aws_lb'].values.first
 
       expect(lb_resource).to include(
-        subnet_mapping: a_collection_including(
-          { subnet_id: '${aws_subnet.a-vpc-private-eu-west-1a.id}' },
-          { subnet_id: '${aws_subnet.a-vpc-private-eu-west-1b.id}' },
-          { subnet_id: '${aws_subnet.a-vpc-private-eu-west-1c.id}' }
+        subnets: a_collection_including(
+          '${aws_subnet.a-vpc-private-eu-west-1a.id}',
+          '${aws_subnet.a-vpc-private-eu-west-1b.id}',
+          '${aws_subnet.a-vpc-private-eu-west-1c.id}',
         )
       )
     end


### PR DESCRIPTION
Use `subnets` for both NLB and ALBs. It seems like terraform gets very confused when it's not there even though it's optional according to the docs.