### PR TITLE
Switch to warning from error for sec groups on NLBs

### DIFF
--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -109,7 +109,7 @@ module Terrafying
         end
 
         if network? && options[:security_groups].count > 0
-          raise "You cannot set security groups on a network loadbalancer, set them on the instances behind it."
+          warn "You cannot set security groups on a network loadbalancer, set them on the instances behind it."
         end
 
         @id = resource :aws_lb, ident, {

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -312,18 +312,19 @@ RSpec.describe Terrafying::Components::LoadBalancer do
 
       expect(lb_resource.keys).to not_include(:idle_timeout)
     end
+    it 'should warn if you try and set security groups' do
+      expect_any_instance_of(Terrafying::Components::LoadBalancer).to receive(:warn).with(
+        matching("You cannot set security groups on a network loadbalancer, set them on the instances behind it.")
+      ).at_least(:once)
 
-    it 'should raise an exception if you try and set security groups' do
-      expect {
-        Terrafying::Components::LoadBalancer.create_in(
-          @vpc, "foo", {
-            ports: [
-              { type: "tcp", number: 1234 },
-            ],
-            security_groups: [ "sg-000" ],
-          }
-        )
-      }.to raise_error RuntimeError
+      described_class.create_in(
+        @vpc, "foo", {
+          ports: [
+            { type: "tcp", number: 1234 },
+          ],
+          security_groups: [ "sg-000" ],
+        }
+      )
     end
   end
 end


### PR DESCRIPTION
As we don't have a good way to not propegate sec groups, let's just warn instead of raising an error.

The code applies security groups only on ALBs already.