### PR TITLE
Compact the arrays to remove nil elements for Keypairs

### DIFF
--- a/lib/terrafying/components/ignition.rb
+++ b/lib/terrafying/components/ignition.rb
@@ -100,7 +100,7 @@ EOF
           raise "All files require the following keys: #{FILE_REQUIRED_KEYS}"
         end
 
-        options[:cas] = options[:keypairs].map { |kp| kp[:ca] }.sort.uniq
+        options[:cas] = options[:keypairs].map { |kp| kp[:ca] }.compact.sort.uniq
 
         erb_path = File.join(File.dirname(__FILE__), "templates/ignition.yaml")
         erb = ERB.new(IO.read(erb_path))

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -87,11 +87,11 @@ module Terrafying
         @ports = enrich_ports(options[:ports])
         @domain_names = [ options[:zone].qualify(name) ]
 
-        depends_on = options[:depends_on] + options[:keypairs].map{ |kp| kp[:resources] }.flatten
+        depends_on = options[:depends_on] + options[:keypairs].map{ |kp| kp[:resources] }.flatten.compact
         if options.key? :instance_profile
           @instance_profile = options[:instance_profile]
         else
-          iam_statements = options[:iam_policy_statements] + options[:keypairs].map { |kp| kp[:iam_statement] }
+          iam_statements = options[:iam_policy_statements] + options[:keypairs].map { |kp| kp[:iam_statement] }.compact
           @instance_profile = add! InstanceProfile.create(ident, { statements: iam_statements })
         end
 


### PR DESCRIPTION
This makes working with keypairs a little simpler as we can leave out elements that aren't needed.