### PR TITLE
Prometheus: expose specific ports via used_by

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -33,7 +33,7 @@ module Terrafying
         options = {
           public: false,
           ami: aws.ami('base-image-24b8d5fb', owners = ['136393635417']),
-          instance_type: 't2.micro',
+          instance_type: 't3a.micro',
           instances: { min: 1, max: 1, desired: 1, tags: {} },
           ports: [],
           instance_profile: nil,

--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -30,8 +30,7 @@ module Terrafying
       def create_in(vpc, name, options = {})
         options = {
           public: false,
-          instance_type: 't2.micro',
-          cpu_credits: 'unlimited',
+          instance_type: 't3a.micro',
           instance_profile: nil,
           ports: [],
           tags: {},
@@ -82,9 +81,6 @@ module Terrafying
         @id = resource :aws_instance, ident, {
           ami: options[:ami],
           instance_type: options[:instance_type],
-          credit_specification: {
-            cpu_credits: options[:cpu_credits]
-          },
           iam_instance_profile: profile_from(options[:instance_profile]),
           subnet_id: @subnet.id,
           associate_public_ip_address: options[:public],

--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -24,8 +24,7 @@ module Terrafying
         prom_name: 'prometheus',
         prom_version: 'v2.9.2',
         instances: 2,
-        instance_type: 't3a.small',
-        instance_cpu_credits: 'standard'
+        instance_type: 't3a.small'
       )
         super()
         @vpc = vpc
@@ -35,7 +34,6 @@ module Terrafying
         @prom_version = prom_version
         @instances = instances
         @instance_type = instance_type
-        @instance_cpu_credits = instance_cpu_credits
       end
 
       def find
@@ -85,7 +83,6 @@ module Terrafying
             }
           ],
           instance_type: @instance_type,
-          cpu_credits: @instance_cpu_credits,
           iam_policy_statements: thanos_store_access,
           instances: [{}] * @instances,
           units: [prometheus_unit, thanos_sidecar_unit],
@@ -120,7 +117,6 @@ module Terrafying
             }
           ],
           instance_type: @instance_type,
-          cpu_credits: @instance_cpu_credits,
           units: [thanos_unit(prometheus_thanos_sidecar_srv_fqdn)],
           instances: [{}] * @instances,
           loadbalancer: true,

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -42,7 +42,7 @@ module Terrafying
       def create_in(vpc, name, options = {})
         options = {
           ami: aws.ami('base-image-24b8d5fb', owners = ['136393635417']),
-          instance_type: 't2.micro',
+          instance_type: 't3a.micro',
           ports: [],
           instances: [{}],
           zone: vpc.zone,

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -38,7 +38,7 @@ module Terrafying
         options = {
           public: false,
           ami: aws.ami('base-image-24b8d5fb', owners = ['136393635417']),
-          instance_type: 't2.micro',
+          instance_type: 't3a.micro',
           subnets: vpc.subnets.fetch(:private, []),
           ports: [],
           instances: [{}],


### PR DESCRIPTION
Also switch default instance type from `t2.micro` to `t3a.micro`.