### PR TITLE
Upgrade Prometheus from v2.9.2 to v2.10.0

### DIFF
--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -22,7 +22,7 @@ module Terrafying
         thanos_name: 'thanos',
         thanos_version: 'v0.4.0',
         prom_name: 'prometheus',
-        prom_version: 'v2.9.2',
+        prom_version: 'v2.10.0',
         instances: 2,
         instance_type: 't3a.small'
       )


### PR DESCRIPTION
Prometheus v2.10.0 is build with go v1.12.5 and comes with significantly
reduced memory usage.

Related upstream issue:
https://github.com/prometheus/prometheus/issues/5524