### PR TITLE
Set instance associate_public_ip_address to true for EIPs

### DIFF
--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -80,7 +80,7 @@ module Terrafying
           @subnet = subnets[subnet_index]
         end
 
-        associate_public_ip_address = !options[:eip] && options[:public]
+        associate_public_ip_address = options[:eip] || options[:public]
 
         @id = resource :aws_instance, ident, {
           ami: options[:ami],
@@ -105,7 +105,7 @@ module Terrafying
           depends_on: options[:depends_on]
         }.merge(options[:ip_address] ? { private_ip: options[:ip_address] } : {}).merge(lifecycle)
 
-        @ip_address = @id[associate_public_ip_address ? :public_ip : :private_ip]
+        @ip_address = @id[options[:public] ? :public_ip : :private_ip]
 
         if options[:eip]
           @eip = resource :aws_eip, ident, {

--- a/spec/terrafying/components/instance_spec.rb
+++ b/spec/terrafying/components/instance_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Terrafying::Components::Instance do
       inst = instance.output['resource']['aws_instance'].values.first
       eip  = instance.output['resource']['aws_eip'].values.first
 
-      expect(inst).to include(associate_public_ip_address: false)
+      expect(inst).to include(associate_public_ip_address: true)
       expect(instance.ip_address.to_s).to match('aws_eip.a-vpc-an-instance.public_ip')
       expect(eip[:instance].to_s).to match('an-instance')
     end


### PR DESCRIPTION
The AWS API strikes again!

When assigning an EIP the AWS API flips an instance's associate_public_ip_address to true, so we will need to set it to true when provisioning an instance (which will give it a public ip from the pool) and then assign an EIP.