### PR TITLE
Upgrade Thanos from v0.4.0 to v0.5.0

### DIFF
--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -20,7 +20,7 @@ module Terrafying
       def initialize(
         vpc:,
         thanos_name: 'thanos',
-        thanos_version: 'v0.4.0',
+        thanos_version: 'v0.5.0',
         prom_name: 'prometheus',
         prom_version: 'v2.10.0',
         instances: 2,


### PR DESCRIPTION
Lower memory usage due to bug fixes and improvements in Thanos and due to improvements in go between v1.12.4 and v1.12.5.