### PR TITLE
Find existing LetsEncrypt CA and key pairs

### DIFF
--- a/lib/terrafying/components/ca.rb
+++ b/lib/terrafying/components/ca.rb
@@ -35,14 +35,33 @@ module Terrafying
         "arn:aws:s3:::#{@bucket}#{key}"
       end
 
-      def object_url(name, type)
-        name = object_name(name, type)
-        key = output_of(:aws_s3_bucket_object, name, :key).to_s
+      def object_url(name, type, version: '')
+        key = object_key(name, type, version)
 
         File.join('s3://', "#{@bucket}#{key}")
       end
 
-      def reference_keypair(ctx, name)
+      def find_keypair(name)
+        reference_keypair(
+          nil, name,
+          key_version: aws.s3_object(@bucket, object_key(name, :key, 'latest')[1..-1]),
+          cert_version: aws.s3_object(@bucket, object_key(name, :cert, 'latest')[1..-1]),
+        )
+      end
+
+      def reference_keypair(ctx, name, key_version:, cert_version:)
+        resources = []
+
+        if ctx != nil
+          resources += [
+            "aws_s3_bucket_object.#{object_name(name, :key)}",
+            "aws_s3_bucket_object.#{object_name(name, :cert)}"
+          ]
+          if ctx == self
+            resources << "aws_s3_bucket_object.#{object_name(@name, :cert)}"
+          end
+        end
+
         ref = {
           name: name,
           ca: self,
@@ -51,13 +70,10 @@ module Terrafying
             key: File.join('/etc/ssl', @name, name, 'key')
           },
           source: {
-            cert: object_url(name, :cert),
-            key: object_url(name, :key)
+            cert: object_url(name, :cert, version: cert_version),
+            key: object_url(name, :key, version: key_version)
           },
-          resources: [
-            "aws_s3_bucket_object.#{object_name(name, :key)}",
-            "aws_s3_bucket_object.#{object_name(name, :cert)}"
-          ],
+          resources: resources,
           iam_statement: {
             Effect: 'Allow',
             Action: [
@@ -71,10 +87,6 @@ module Terrafying
             ]
           }
         }
-
-        if self == ctx
-          ref[:resources] << "aws_s3_bucket_object.#{object_name(@name, :cert)}"
-        end
 
         ref
       end


### PR DESCRIPTION
We don't want to keep issuing certificates for the same domains, so this
lets us generate them once and then reference them again. Useful for
Envoy stuff!