### PR TITLE
Upgrade Prometheus from v2.10.0 to v2.11.2

### DIFF
--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -22,7 +22,7 @@ module Terrafying
         thanos_name: 'thanos',
         thanos_version: 'v0.5.0',
         prom_name: 'prometheus',
-        prom_version: 'v2.10.0',
+        prom_version: 'v2.11.2',
         instances: 2,
         instance_type: 't3a.small',
         thanos_instance_type: 't3a.small',


### PR DESCRIPTION
Security fix for stored DOM XSS, usual miscellaneous fixes and improvements.