### PR TITLE
Upgrade Prometheus from v2.11.2 to v2.12.0

### DIFF
--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -22,7 +22,7 @@ module Terrafying
         thanos_name: 'thanos',
         thanos_version: 'v0.5.0',
         prom_name: 'prometheus',
-        prom_version: 'v2.11.2',
+        prom_version: 'v2.12.0',
         instances: 2,
         instance_type: 't3a.small',
         thanos_instance_type: 't3a.small',


### PR DESCRIPTION
Routine bugfixes and improvements.

Release:
https://github.com/prometheus/prometheus/releases/tag/v2.12.0

Diff:
https://github.com/prometheus/prometheus/compare/v2.11.2...v2.12.0