### PR TITLE
Upgrade CoreOS base image to v2191.5.0

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -33,7 +33,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-f074c65a', owners = ['136393635417']),
+          ami: aws.ami('base-image-bad2d2af', owners = ['136393635417']),
           instance_type: 't3a.micro',
           instances: { min: 1, max: 1, desired: 1, tags: {} },
           ports: [],

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -41,7 +41,7 @@ module Terrafying
 
       def create_in(vpc, name, options = {})
         options = {
-          ami: aws.ami('base-image-f074c65a', owners = ['136393635417']),
+          ami: aws.ami('base-image-bad2d2af', owners = ['136393635417']),
           instance_type: 't3a.micro',
           ports: [],
           instances: [{}],

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -38,7 +38,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-f074c65a', owners = ['136393635417']),
+          ami: aws.ami('base-image-bad2d2af', owners = ['136393635417']),
           instance_type: 't3a.micro',
           subnets: vpc.subnets.fetch(:private, []),
           ports: [],


### PR DESCRIPTION
Previous base image: `CoreOS-stable-2079.5.1-hvm`
New base image: `CoreOS-stable-2191.5.0-hvm`

Lots of changes, including security fixes and updates to the kernel.

Release notes:
https://coreos.com/releases/