### PR TITLE
Correct lambda IAM policy

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -295,12 +295,10 @@ module Terrafying
                         "route53:GetChange",
                         "route53:ChangeResourceRecordSets",
                       ],
-                      Resource: [
+                      Resource:
                         domains.map { | domain |
                           "arn:aws:route53:::#{domain.zone.id[1..-1]}"
-                         },
-                        "arn:aws:route53:::change/*",
-                      ],
+                        },
                       Effect: "Allow"
                     }
                   ]


### PR DESCRIPTION
* `.map` outputs a new array, so the extra square brackets need dropping, otherwise the ouput JSON is invalid
* Not convinced that the `change` resource is needed, so dropping for now 