### PR TITLE
Add CW log group and logging permissions for lambda

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -292,6 +292,17 @@ module Terrafying
                     },
                     {
                       Action: [
+                        "logs:CreateLogGroup",
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents"
+                      ],
+                      Resource: [
+                        "arn:aws:logs:*:*:*"
+                      ],
+                      Effect: "Allow"
+                    },
+                    {
+                      Action: [
                         "route53:ListHostedZones",
                         "route53:GetChange",
                         "route53:ChangeResourceRecordSets",
@@ -310,6 +321,11 @@ module Terrafying
         resource :aws_iam_role_policy_attachment, "#{@name}_lambda_policy_attachment", {
             role: "${aws_iam_role.#{@name}_lambda_execution.name}",
             policy_arn: "${aws_iam_policy.#{@name}_lambda_s3.arn}"
+            }
+
+        resource :aws_cloudwatch_log_group, "#{@name}", {
+            name: "/aws/lambda/#{@name}_lambda",
+            retention_in_days: 14
             }
 
           self

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -323,11 +323,6 @@ module Terrafying
             policy_arn: "${aws_iam_policy.#{@name}_lambda_s3.arn}"
             }
 
-        resource :aws_cloudwatch_log_group, "#{@name}", {
-            name: "/aws/lambda/#{@name}_lambda",
-            retention_in_days: 14
-            }
-
           self
         end
 


### PR DESCRIPTION
* Adds cloudwatch logs IAM permissions ~(as well as a log group)~ so certbot lambda can output logs there