### PR TITLE
Only create renewal lambda bits if renewing is explicitly set

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -152,10 +152,6 @@ module Terrafying
         }.merge(options)
 
         @zones << options[:zone]
-        # we don't want to create LE certs if not renewing (excluding legacy), so raise an exception if that's the case
-        if @zones.length > 0 and @renewing == false and not caller_locations.to_s.match? /envoy.rb/
-          raise "Can't create Let's Encrypt domains without setting up the renewal!"
-        end
 
         key_ident = "#{@name}-#{tf_safe(name)}"
 

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -16,13 +16,11 @@ module Terrafying
       def self.find(name, bucket, options = {})
         LetsEncrypt.new.find name, bucket, options
       end
-      def self.renew(name, bucket, domains, options = {})
-        LetsEncrypt.new.renew name, bucket, domains, options
-      end
 
       def initialize
         super
         @acme_providers = setup_providers
+        @zones = []
       end
 
       def setup_providers
@@ -48,7 +46,8 @@ module Terrafying
           public_certificate: false,
           curve: 'P384',
           rsa_bits: '3072',
-          use_external_dns: false
+          use_external_dns: false,
+          renewing: false
         }.merge(options)
 
         @name = name
@@ -56,6 +55,9 @@ module Terrafying
         @prefix = options[:prefix]
         @acme_provider = @acme_providers[options[:provider]]
         @use_external_dns = options[:use_external_dns]
+        @renewing = options[:renewing]
+
+        renew() if @renewing
 
         provider :tls, {}
 
@@ -146,7 +148,15 @@ module Terrafying
           dns_names: [],
           ip_addresses: [],
           curve: "P384",
+          zone: ""
         }.merge(options)
+
+        @zones << options[:zone]
+        # we don't want to create LE certs if not renewing (excluding legacy), so raise an exception if that's the case
+        # temporarily ignore calls from rspec tests
+        if @zones.length > 0 and @renewing == false and not caller_locations.to_s.match? /envoy.rb|rspec/
+          raise "Can't create Let's Encrypt domains without setting up the renewal!"
+        end
 
         key_ident = "#{@name}-#{tf_safe(name)}"
 
@@ -203,11 +213,14 @@ module Terrafying
 
         cert_version = "${sha256(acme_certificate.#{key_ident}.certificate_pem)}"
 
-        ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert",
+        cert_config = {
                      bucket: @bucket,
                      key: object_key(name, :cert, cert_version),
                      content: output_of(:acme_certificate, key_ident, :certificate_pem).to_s + @ca_cert,
-                     lifecycle: { ignore_changes: [ "content" ] } # the lambda will be updating it
+        }
+        cert_config[:lifecycle] = { ignore_changes: [ "content" ] } if @renewing
+
+        ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert", cert_config
 
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert-latest",
                      bucket: @bucket,
@@ -217,55 +230,12 @@ module Terrafying
         reference_keypair(ctx, name, key_version: key_version, cert_version: cert_version)
       end
 
-      def renew(name, bucket, domains, options={})
-        options = {
-          prefix: "",
-          provider: :staging,
-        }.merge(options)
-
-        @name = name
-        @bucket = bucket
-        @domains = domains
-        @prefix = options[:prefix]
-
-        resource :aws_lambda_function, "#{@name}_lambda", {
-          function_name: "#{@name}_lambda",
-          s3_bucket: "uswitch-certbot-lambda",
-          s3_key: "certbot-lambda.zip",
-          handler: "main.handler",
-          runtime: "python3.7",
-          timeout: "900",
-          role: "${aws_iam_role.#{@name}_lambda_execution.arn}",
-          environment:{
-            variables: {
-              CA_BUCKET: @bucket,
-              CA_PREFIX: @prefix,
-            }
-          }
-        }
-
-        resource :aws_iam_role, "#{@name}_lambda_execution", {
-          name: "#{@name}_lambda_execution",
-          assume_role_policy: JSON.pretty_generate(
-                {
-                  Version: "2012-10-17",
-                  Statement: [
-                    {
-                      Action: "sts:AssumeRole",
-                      Principal: {
-                        Service: "lambda.amazonaws.com"
-                        },
-                      Effect: "Allow",
-                      Sid: ""
-                    }
-                  ]
-                }
-              )
-            }
-
-        resource :aws_iam_policy, "#{@name}_lambda_execution_policy", {
-          name: "#{@name}_lambda_execution_policy",
-          description: "A policy for the #{@name}-lambda function to access S3",
+      def output_with_children
+        iam_policy = {}
+        if @renewing
+          iam_policy = resource :aws_iam_policy, "#{@bucket}_lambda_execution_policy", {
+          name: "#{@bucket}_lambda_execution_policy",
+          description: "A policy for the #{@bucket}_lambda function to access S3",
           policy: JSON.pretty_generate(
                 {
                   Version: "2012-10-17",
@@ -277,7 +247,7 @@ module Terrafying
                         "s3:DeleteObject"
                       ],
                       Resource: [
-                        "arn:aws:s3:::#{@bucket}/#{@prefix}/*"
+                        "arn:aws:s3:::#{@bucket}/#{@name}/*"
                       ],
                       Effect: "Allow"
                     },
@@ -324,8 +294,8 @@ module Terrafying
                         "route53:ChangeResourceRecordSets",
                       ],
                       Resource:
-                        domains.map { | domain |
-                          "arn:aws:route53:::#{domain.zone.id[1..-1]}"
+                        @zones.map { | zone |
+                          "arn:aws:route53:::#{zone.id[1..-1]}"
                         },
                       Effect: "Allow"
                     }
@@ -333,10 +303,49 @@ module Terrafying
                 }
               )
             }
+          end
+        super
+      end
 
-        resource :aws_iam_role_policy_attachment, "#{@name}_lambda_policy_attachment", {
-            role: "${aws_iam_role.#{@name}_lambda_execution.name}",
-            policy_arn: "${aws_iam_policy.#{@name}_lambda_execution_policy.arn}"
+      def renew
+        resource :aws_lambda_function, "#{@bucket}_lambda", {
+          function_name: "#{@bucket}_lambda",
+          s3_bucket: "uswitch-certbot-lambda",
+          s3_key: "certbot-lambda.zip",
+          handler: "main.handler",
+          runtime: "python3.7",
+          timeout: "900",
+          role: "${aws_iam_role.#{@bucket}_lambda_execution.arn}",
+          environment:{
+            variables: {
+              CA_BUCKET: @bucket,
+              CA_PREFIX: @name,
+            }
+          }
+        }
+
+        resource :aws_iam_role, "#{@bucket}_lambda_execution", {
+          name: "#{@bucket}_lambda_execution",
+          assume_role_policy: JSON.pretty_generate(
+                {
+                  Version: "2012-10-17",
+                  Statement: [
+                    {
+                      Action: "sts:AssumeRole",
+                      Principal: {
+                        Service: "lambda.amazonaws.com"
+                        },
+                      Effect: "Allow",
+                      Sid: ""
+                    }
+                  ]
+                }
+              )
+            }
+
+        resource :aws_iam_role_policy_attachment, "#{@bucket}_lambda_policy_attachment", {
+            role: "${aws_iam_role.#{@bucket}_lambda_execution.name}",
+            policy_arn: "${aws_iam_policy.#{@bucket}_lambda_execution_policy.arn}"
             }
 
           self

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -147,11 +147,10 @@ module Terrafying
           organization: "uSwitch Limited",
           dns_names: [],
           ip_addresses: [],
-          curve: "P384",
-          zone: ""
+          curve: "P384"
         }.merge(options)
 
-        @zones << options[:zone]
+        @zones << options[:zone] if options[:zone]
 
         key_ident = "#{@name}-#{tf_safe(name)}"
 

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -153,8 +153,7 @@ module Terrafying
 
         @zones << options[:zone]
         # we don't want to create LE certs if not renewing (excluding legacy), so raise an exception if that's the case
-        # temporarily ignore calls from rspec tests
-        if @zones.length > 0 and @renewing == false and not caller_locations.to_s.match? /envoy.rb|rspec/
+        if @zones.length > 0 and @renewing == false and not caller_locations.to_s.match? /envoy.rb/
           raise "Can't create Let's Encrypt domains without setting up the renewal!"
         end
 
@@ -295,7 +294,7 @@ module Terrafying
                       ],
                       Resource:
                         @zones.map { | zone |
-                          "arn:aws:route53:::#{zone.id[1..-1]}"
+                          "arn:aws:route53:::#{zone.id[1..-1]}" if zone != ""
                         },
                       Effect: "Allow"
                     }

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -226,13 +226,13 @@ module Terrafying
       end
 
       def output_with_children
-        @prefix_path = File.join(@name, @prefix)
+        @prefix_path = [@prefix, @name].reject(&:empty?).join("/")
 
         iam_policy = {}
         if @renewing
           iam_policy = resource :aws_iam_policy, "#{@name}_lambda_execution_policy", {
           name: "#{@name}_lambda_execution_policy",
-          description: "A policy for the #{@name}_lambda function to access S3",
+          description: "A policy for the #{@name}_lambda function to access S3 and R53",
           policy: JSON.pretty_generate(
                 {
                   Version: "2012-10-17",
@@ -291,8 +291,8 @@ module Terrafying
                         "route53:ChangeResourceRecordSets",
                       ],
                       Resource:
-                        @zones.reject { | z | z.empty? }.map { | zone |
-                          "arn:aws:route53:::#{zone.id[1..-1]}."
+                        @zones.reject(&:nil?).map { | zone |
+                          "arn:aws:route53:::#{zone.id[1..-1]}"
                         },
                       Effect: "Allow"
                     }

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -291,7 +291,7 @@ module Terrafying
                         "route53:ChangeResourceRecordSets",
                       ],
                       Resource:
-                        @zones.reject{ | z | z.nil? || z.to_s.empty? }.map { | zone |
+                        @zones.reject(&:nil?).map { | zone |
                           "arn:aws:route53:::#{zone.id[1..-1]}"
                         },
                       Effect: "Allow"

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -227,6 +227,7 @@ module Terrafying
 
       def output_with_children
         @prefix_path = [@prefix, @name].reject(&:empty?).join("/")
+        @zones.select! { | zone | zone&.to_s.size.to_i > 0 }
 
         iam_policy = {}
         if @renewing
@@ -291,7 +292,7 @@ module Terrafying
                         "route53:ChangeResourceRecordSets",
                       ],
                       Resource:
-                        @zones.reject(&:nil?).map { | zone |
+                        @zones.map { | zone |
                           "arn:aws:route53:::#{zone.id[1..-1]}"
                         },
                       Effect: "Allow"

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -227,7 +227,6 @@ module Terrafying
 
       def output_with_children
         @prefix_path = [@prefix, @name].reject(&:empty?).join("/")
-        @zones.select! { | zone | zone&.to_s.size.to_i > 0 }
 
         iam_policy = {}
         if @renewing
@@ -292,7 +291,7 @@ module Terrafying
                         "route53:ChangeResourceRecordSets",
                       ],
                       Resource:
-                        @zones.map { | zone |
+                        @zones.reject{ | z | z.nil? || z.to_s.empty? }.map { | zone |
                           "arn:aws:route53:::#{zone.id[1..-1]}"
                         },
                       Effect: "Allow"

--- a/spec/support/shared_examples/ca.rb
+++ b/spec/support/shared_examples/ca.rb
@@ -16,7 +16,7 @@ shared_examples 'a CA' do
   end
 
   before do
-    @ca = described_class.create(ca_name, bucket_name, renewing: true)
+    @ca = described_class.create(ca_name, bucket_name)
   end
 
   describe '.create' do
@@ -143,7 +143,7 @@ shared_examples 'a CA' do
     end
 
     it 'should have keys/certs that start with "/" when it has no prefix' do
-      ca = described_class.create(ca_name, bucket_name, renewing: true)
+      ca = described_class.create(ca_name, bucket_name)
       ca.create_keypair('bar')
 
       s3_objects = ca.output['resource']['aws_s3_bucket_object'].values
@@ -152,7 +152,7 @@ shared_examples 'a CA' do
     end
 
     it 'should have keys/certs that start with "/" when it has a prefix' do
-      ca = described_class.create(ca_name, bucket_name, renewing: true, prefix: 'a_prefix')
+      ca = described_class.create(ca_name, bucket_name, prefix: 'a_prefix')
       ca.create_keypair('bar')
 
       s3_objects = ca.output['resource']['aws_s3_bucket_object'].values

--- a/spec/support/shared_examples/ca.rb
+++ b/spec/support/shared_examples/ca.rb
@@ -16,7 +16,7 @@ shared_examples 'a CA' do
   end
 
   before do
-    @ca = described_class.create(ca_name, bucket_name)
+    @ca = described_class.create(ca_name, bucket_name, renewing: true)
   end
 
   describe '.create' do
@@ -143,7 +143,7 @@ shared_examples 'a CA' do
     end
 
     it 'should have keys/certs that start with "/" when it has no prefix' do
-      ca = described_class.create(ca_name, bucket_name)
+      ca = described_class.create(ca_name, bucket_name, renewing: true)
       ca.create_keypair('bar')
 
       s3_objects = ca.output['resource']['aws_s3_bucket_object'].values
@@ -152,7 +152,7 @@ shared_examples 'a CA' do
     end
 
     it 'should have keys/certs that start with "/" when it has a prefix' do
-      ca = described_class.create(ca_name, bucket_name, prefix: 'a_prefix')
+      ca = described_class.create(ca_name, bucket_name, renewing: true, prefix: 'a_prefix')
       ca.create_keypair('bar')
 
       s3_objects = ca.output['resource']['aws_s3_bucket_object'].values

--- a/spec/terrafying/components/letsencrypt_spec.rb
+++ b/spec/terrafying/components/letsencrypt_spec.rb
@@ -19,7 +19,7 @@ end
 RSpec.describe Terrafying::Components::LetsEncrypt, '#create' do
   context 'providers' do
     it 'creates the provider for staging' do
-      ca = Terrafying::Components::LetsEncrypt.create('test-ca', 'test-bucket', renewing: true)
+      ca = Terrafying::Components::LetsEncrypt.create('test-ca', 'test-bucket')
 
       prov = provider_matching(ca, :acme, :staging)
 
@@ -36,7 +36,6 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create' do
         'test-ca',
         'test-bucket',
         prefix: 'test-prefix',
-        renewing: true,
         provider: :staging
       )
 
@@ -46,7 +45,7 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create' do
     end
 
     it 'creates the provider for live' do
-      ca = Terrafying::Components::LetsEncrypt.create('test-ca', 'test-bucket', renewing: true)
+      ca = Terrafying::Components::LetsEncrypt.create('test-ca', 'test-bucket')
 
       prov = provider_matching(ca, :acme, :live)
 
@@ -63,7 +62,6 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create' do
         'test-ca',
         'test-bucket',
         prefix: 'test-prefix',
-        renewing: true,
         provider: :live
       )
 
@@ -81,7 +79,6 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
         'test-ca',
         'test-bucket',
         prefix: 'test-prefix',
-        renewing: true,
         provider: :staging
       )
 
@@ -98,7 +95,6 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
         'test-bucket',
         prefix: 'test-prefix',
         provider: :staging,
-        renewing: true,
         use_external_dns: true
       )
 
@@ -114,7 +110,6 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
         'test-ca',
         'test-bucket',
         prefix: 'test-prefix',
-        renewing: true,
         provider: :staging,
       )
 

--- a/spec/terrafying/components/letsencrypt_spec.rb
+++ b/spec/terrafying/components/letsencrypt_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
 
       certbot = ca.output_with_children['resource']['aws_lambda_function'].values.first
 
-      expect(certbot[:function_name]).to eq('test-bucket_lambda')
+      expect(certbot[:function_name]).to eq('test-ca_lambda')
     end
   end
 end

--- a/spec/terrafying/components/letsencrypt_spec.rb
+++ b/spec/terrafying/components/letsencrypt_spec.rb
@@ -124,5 +124,20 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
 
       expect(cert.key? :recursive_nameservers).to eq(false)
     end
+
+    it 'creates the certbot lambda' do
+      ca = Terrafying::Components::LetsEncrypt.create(
+        'test-ca',
+        'test-bucket',
+        prefix: 'test-prefix',
+        renewing: true
+      )
+
+      ca.create_keypair('test-cert', dns_names: ['test.example.com'])
+
+      certbot = ca.output_with_children['resource']['aws_lambda_function'].values.first
+
+      expect(certbot[:function_name]).to eq('test-bucket_lambda')
+    end
   end
 end

--- a/spec/terrafying/components/letsencrypt_spec.rb
+++ b/spec/terrafying/components/letsencrypt_spec.rb
@@ -119,20 +119,60 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
 
       expect(cert.key? :recursive_nameservers).to eq(false)
     end
+  end
+end
 
-    it 'creates the certbot lambda' do
-      ca = Terrafying::Components::LetsEncrypt.create(
-        'test-ca',
-        'test-bucket',
-        prefix: 'test-prefix',
-        renewing: true
-      )
+RSpec.describe Terrafying::Components::LetsEncrypt, '#renewing' do
+  context 'providers' do
+    let(:id) {@id}
 
-      ca.create_keypair('test-cert', dns_names: ['test.example.com'])
+    def fake_hosted_zone(fqdn)
+      @hosted_zones ||= {}
+      @hosted_zones[fqdn] ||=
+        begin
+          warn "looking for a hosted zone with fqdn '#{fqdn}'"
+          hosted_zones = @route53_client.stub_data(:list_hosted_zones_by_name, dns_name: fqdn, hosted_zones:[{id: 'IAMAZONESWEARS', name: fqdn + ".", config: {private_zone: false}}]).hosted_zones.select do |zone|
+            zone.name == "#{fqdn}." && !zone.config.private_zone
+          end
+          if hosted_zones.count == 1
+            hosted_zones.first
+          elsif hosted_zones.count < 1
+            raise "No hosted zone with fqdn '#{fqdn}' was found."
+          elsif hosted_zones.count > 1
+            raise "More than one hosted zone with name '#{fqdn}' was found: " + hosted_zones.join(', ')
+          end
+        end
+      end
 
-      certbot = ca.output_with_children['resource']['aws_lambda_function'].values.first
+      def fake_find(fqdn)
+        zone = fake_hosted_zone(fqdn)
 
-      expect(certbot[:function_name]).to eq('test-ca_lambda')
-    end
+        @id = zone.id
+        @fqdn = fqdn
+
+        self
+      end
+
+      it 'creates the certbot lambda' do
+        @route53_client = Aws::Route53::Client.new(stub_responses: true)
+
+        ca = Terrafying::Components::LetsEncrypt.create(
+          'test-ca',
+          'test-bucket',
+          prefix: 'test-prefix',
+          renewing: true
+        )
+
+        # in another world we could just set zone to nil because it get squish
+        # ca.create_keypair('test-cert', dns_names: ['test.example.com'], zone: nil)
+
+        zone = fake_find('test.example.com')
+        ca.create_keypair('test-cert', dns_names: ['test.example.com'], zone: zone)
+
+        certbot = ca.output_with_children['resource']['aws_lambda_function'].values.first
+
+        expect(certbot[:function_name]).to eq('test-ca_lambda')
+      end
+
   end
 end

--- a/spec/terrafying/components/letsencrypt_spec.rb
+++ b/spec/terrafying/components/letsencrypt_spec.rb
@@ -19,7 +19,7 @@ end
 RSpec.describe Terrafying::Components::LetsEncrypt, '#create' do
   context 'providers' do
     it 'creates the provider for staging' do
-      ca = Terrafying::Components::LetsEncrypt.create('test-ca', 'test-bucket')
+      ca = Terrafying::Components::LetsEncrypt.create('test-ca', 'test-bucket', renewing: true)
 
       prov = provider_matching(ca, :acme, :staging)
 
@@ -36,6 +36,7 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create' do
         'test-ca',
         'test-bucket',
         prefix: 'test-prefix',
+        renewing: true,
         provider: :staging
       )
 
@@ -45,7 +46,7 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create' do
     end
 
     it 'creates the provider for live' do
-      ca = Terrafying::Components::LetsEncrypt.create('test-ca', 'test-bucket')
+      ca = Terrafying::Components::LetsEncrypt.create('test-ca', 'test-bucket', renewing: true)
 
       prov = provider_matching(ca, :acme, :live)
 
@@ -62,6 +63,7 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create' do
         'test-ca',
         'test-bucket',
         prefix: 'test-prefix',
+        renewing: true,
         provider: :live
       )
 
@@ -79,6 +81,7 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
         'test-ca',
         'test-bucket',
         prefix: 'test-prefix',
+        renewing: true,
         provider: :staging
       )
 
@@ -95,6 +98,7 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
         'test-bucket',
         prefix: 'test-prefix',
         provider: :staging,
+        renewing: true,
         use_external_dns: true
       )
 
@@ -110,6 +114,7 @@ RSpec.describe Terrafying::Components::LetsEncrypt, '#create_keypair' do
         'test-ca',
         'test-bucket',
         prefix: 'test-prefix',
+        renewing: true,
         provider: :staging,
       )
 


### PR DESCRIPTION
* This makes the required certbot renewal resources optional when calling the Lets Encrypt ca create
* Also addresses the TF lifecycle/ignore_changes issue where certs are not uploaded to S3 when renewing via TF (as content changes to S3 bucket object is ignored) - this is now only true if renewing