### PR TITLE
Self signed certs will renew before they are expired

### DIFF
--- a/lib/terrafying/components/selfsignedca.rb
+++ b/lib/terrafying/components/selfsignedca.rb
@@ -66,6 +66,7 @@ module Terrafying
                    common_name: options[:common_name],
                    organization: options[:organization]
                  },
+                 early_renewal_hours: 24 * 30,
                  is_ca_certificate: true,
                  validity_period_hours: 24 * 365,
                  allowed_uses: %w[


### PR DESCRIPTION
As per the PR, self signed certs will be renewed 30 days before they
expire.

Note: if new certs is generated, terraform can't revoke existing cert.
it will be valid till it's expiration time.

Reference:

[0] https://www.terraform.io/docs/providers/tls/r/self_signed_cert.html#early_renewal_hours
[1] https://apparently.me.uk/terraform-certificate-authority/
[2] https://www.terraform.io/docs/providers/acme/r/certificate.html#min_days_remaining