### PR TITLE
Stop Terraform from trying to renew certs when we have the lambda

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -172,10 +172,12 @@ module Terrafying
         cert_options = {}
         cert_options[:recursive_nameservers] = ['1.1.1.1:53', '8.8.8.8:53', '8.8.4.4:53'] if @use_external_dns
 
+        @renewing ? min_days_remaining = 0 : min_days_remaining = 21
+        # we don't want Terraform to renew certs if the certbot lambda is provisioned
         ctx.resource :acme_certificate, key_ident, {
                      provider: @acme_provider[:ref],
                      account_key_pem: @account_key,
-                     min_days_remaining: 21,
+                     min_days_remaining: min_days_remaining,
                      dns_challenge: {
                        provider: 'route53'
                      },


### PR DESCRIPTION
Ref: https://www.terraform.io/docs/providers/acme/r/certificate.html#certificate-renewal