### PR TITLE
Specify absolute path to cert for path unit

### DIFF
--- a/lib/terrafying/components/vpn_oidc.rb
+++ b/lib/terrafying/components/vpn_oidc.rb
@@ -209,7 +209,7 @@ module Terrafying
             [Unit]
             Description=Monitor the file for changes
             [Path]
-            PathChanged=/etc/ssl/#{@ca.name}
+            PathChanged=/etc/ssl/#{@ca.name}/#{@fqdn}/cert
             Unit=restart-openvpn-authz.service
             [Install]
             WantedBy=multi-user.target


### PR DESCRIPTION
The `PathChanged` option in systemd path units doesn't seem to be recursive, so adding absolute path to cert for the unit. My reasoning is that if the key changes, the cert will have changed as it will be signed with the new key, so no need to monitor changes to the key file.