### PR TITLE
Fix cronjob timer

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -369,11 +369,12 @@ module Terrafying
         self
       end
 
-      def generate_alpha_num
-        @name.split("").each do |ch|
+      def generate_alpha_num()
+        result = @name.split("").each do |ch|
           alpha_num = ch.upcase.ord - 'A'.ord
-          return alpha_num if (alpha_num < 24)
+          return alpha_num.abs if (alpha_num.abs < 24)
         end
+        result.is_a?(Integer) ? result : 6
       end
 
     end

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -345,11 +345,12 @@ module Terrafying
           policy_arn: "${aws_iam_policy.#{@name}_lambda_execution_policy.arn}"
         }
 
-        rand_hour = rand(0..23).to_s
+        alpha_num = generate_alpha_num().to_s
+
         event_rule = resource :aws_cloudwatch_event_rule, "once_per_day", {
           name: "once-per-day",
           description: "Fires once per day",
-          schedule_expression: "cron(0 #{rand_hour} * * ? *)"
+          schedule_expression: "cron(0 #{alpha_num} * * ? *)"
         }
 
         resource :aws_cloudwatch_event_target, "#{@name}_lambda_event_target", {
@@ -366,6 +367,13 @@ module Terrafying
           source_arn: event_rule["arn"]
         }
         self
+      end
+
+      def generate_alpha_num
+        @name.split("").each do |ch|
+          alpha_num = ch.upcase.ord - 'A'.ord
+          return alpha_num if (alpha_num < 24)
+        end
       end
 
     end


### PR DESCRIPTION
Choosing to iterate in case the first letter is Y - 24 or  Z - 25 as these are invalid times. Example of this is Yggdrasil.

Some non alphanumeric characters get skipped. e.g. \, #, $

Other non alphanumeric characters have negative values. e.g. -, ., /
Using `.abs` make these acceptable.

If after iterating through the @name string there is not a valid letter, then we arbitrarily default to 6