### PR TITLE
Use service_name tag and use as label

### DIFF
--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -272,6 +272,8 @@ module Terrafying
                 target_label: instance_id
               - source_labels: [__meta_ec2_tag_envoy_cluster]
                 target_label: envoy_cluster
+              - source_labels: [__meta_ec2_tag_service_name]
+                target_label: service_name
             <%- end -%>
             <%- @prometheus_additional_scrape_configs.each do |conf| -%>
             <%= conf %>


### PR DESCRIPTION
As service_name is added for us here - https://github.com/uswitch/terrafying-components/blob/master/lib/terrafying/components/dynamicset.rb#L107

I thought it might be useful to use this to help with Prom queries.

Thought about adding extra config here - https://github.com/uswitch/terrafying-vault/blob/master/specs/data/vpc.rb#L72, but thought it would be easier add the label here instead