### PR TITLE
Allow use with terraform v0.12.x and add metadata options for aws_launch_config

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -44,8 +44,11 @@ module Terrafying
           subnets: vpc.subnets.fetch(:private, []),
           depends_on: [],
           rolling_update: :simple,
+          metadata_options: {},
           vpc_endpoints_egress: []
         }.merge(options)
+
+        metadata_options = options[:metadata_options]
 
         ident = "#{tf_safe(vpc.name)}-#{name}"
 
@@ -85,6 +88,7 @@ module Terrafying
                                  lifecycle: {
                                    create_before_destroy: true
                                  },
+                                 metadata_options: options[:metadata_options],
                                  depends_on: resource_name_from(options[:instance_profile])
 
         if options[:instances][:track]

--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -36,8 +36,14 @@ module Terrafying
           instance_profile: nil,
           ports: [],
           tags: {},
-          security_groups: [],
-          depends_on: []
+          security_groups: nil,
+          metadata_options: nil,
+          depends_on: nil,
+          ipv6_cidr_blocks: nil,
+          prefix_list_ids: nil,
+          security_groups: nil,
+          self: nil,
+          description: nil,
         }.merge(options)
 
         ident = "#{tf_safe(vpc.name)}-#{name}"
@@ -55,7 +61,12 @@ module Terrafying
                                        from_port: 0,
                                        to_port: 0,
                                        protocol: -1,
-                                       cidr_blocks: ['0.0.0.0/0']
+                                       cidr_blocks: ['0.0.0.0/0'],
+                                       ipv6_cidr_blocks: options[:ipv6_cidr_blocks],
+                                       prefix_list_ids: options[:prefix_list_ids],
+                                       security_groups: options[:security_groups],
+                                       self: options[:self],
+                                       description: options[:description]
                                      }
                                    ]
 
@@ -99,6 +110,7 @@ module Terrafying
             vpc.internal_ssh_security_group
           ].push(*options[:security_groups]),
           user_data: options[:user_data],
+          metadata_options: options[:metadata_options],
           lifecycle: {
             create_before_destroy: true
           },

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'digest'
+require 'digest/bubblebabble'
 require 'terrafying/components/usable'
 require 'terrafying/generator'
 
@@ -217,7 +217,7 @@ module Terrafying
 
       def make_identifier(type, vpc_name, name)
         gen_id = "#{type}-#{tf_safe(vpc_name)}-#{name}"
-        return Digest::SHA2.hexdigest(gen_id)[0..24] if @hex_ident || gen_id.size > 26
+        return Digest::SHA256.bubblebabble(gen_id)[0..15] if @hex_ident || gen_id.size > 26
 
         gen_id[0..31]
       end

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -59,6 +59,7 @@ module Terrafying
           subnets: vpc.subnets.fetch(:private, []),
           startup_grace_period: 300,
           depends_on: [],
+          metadata_options: {},
           audit_role: "arn:aws:iam::#{aws.account_id}:role/auditd_logging",
           metrics_ports: [],
           vpc_endpoints_egress: []
@@ -96,6 +97,8 @@ module Terrafying
           @instance_profile = add! InstanceProfile.create(ident, statements: iam_statements)
         end
 
+        metadata_options = options[:metadata_options]
+
         tags = options[:tags].merge(service_name: name)
 
         set = options[:instances].is_a?(Hash) ? DynamicSet : StaticSet
@@ -112,6 +115,7 @@ module Terrafying
         instance_set_options = {
           instance_profile: @instance_profile,
           depends_on: depends_on,
+          metadata_options: metadata_options,
           tags: tags
         }
 

--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -184,7 +184,12 @@ module Terrafying
                                                     from_port: 22,
                                                     to_port: 22,
                                                     protocol: 'tcp',
-                                                    cidr_blocks: [@cidr]
+                                                    cidr_blocks: [@cidr],
+                                                    description: nil, 
+                                                    ipv6_cidr_blocks: nil, 
+                                                    prefix_list_ids: nil, 
+                                                    security_groups: nil,
+                                                    self: nil
                                                   }
                                                 ],
                                                 egress: [
@@ -192,7 +197,12 @@ module Terrafying
                                                     from_port: 22,
                                                     to_port: 22,
                                                     protocol: 'tcp',
-                                                    cidr_blocks: [@cidr]
+                                                    cidr_blocks: [@cidr],
+                                                    description: nil, 
+                                                    ipv6_cidr_blocks: nil, 
+                                                    prefix_list_ids: nil, 
+                                                    security_groups: nil,
+                                                    self: nil
                                                   }
                                                 ]
         self

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'digest'
+require 'digest/bubblebabble'
 require 'terrafying'
 require 'terrafying/components/instance'
 require 'terrafying/components/loadbalancer'
@@ -91,15 +91,15 @@ RSpec.describe Terrafying::Components::LoadBalancer do
     expect(lb.name.length).to be <= 32
   end
 
-  it 'should use hex identifiers when requested' do
-    name = 'abcdefghijklmnopqrstuvwxyz123456789'
-    expected_hex = Digest::SHA2.hexdigest("application-#{@vpc.name}-#{name}")[0..24]
+  it 'should use bubblebabble identifiers when requested' do
+    name = 'abcde-fghi-jklm'
+    expected_bubblebabble = Digest::SHA256.bubblebabble("application-#{@vpc.name}-#{name}")[0..15]
 
     lb = Terrafying::Components::LoadBalancer.create_in(
       @vpc, name, hex_ident: true
     )
 
-    expect(lb.name).to eq(expected_hex)
+    expect(lb.name).to eq(expected_bubblebabble)
   end
 
   context('application load balancer') do

--- a/spec/terrafying/components/vpc_spec.rb
+++ b/spec/terrafying/components/vpc_spec.rb
@@ -161,7 +161,12 @@ end
       from_port: 22,
       to_port: 22,
       protocol: 'tcp',
-      cidr_blocks: [cidr]
+      cidr_blocks: [cidr],
+      description: nil, 
+      ipv6_cidr_blocks: nil, 
+      prefix_list_ids: nil, 
+      security_groups: nil,
+      self: nil
     }
 
     expect(ssh_security_group[:ingress][0]).to eq(rule)


### PR DESCRIPTION
This commit will allow terrafying-components to be compatible with terraform v0.12.x.
If you're still using terraform v0.11.x please use an older version of terrafying-components.
`bundle exec terrafying json xxx.rb > xxx.tf.json` is required when using terraform v0.12.x

Changes:
Added metadata_option for aws_launch_configuration. (currently requires custom aws provider)
Added additional keys required for security_groups.
Changed the use of hexdigest to bubblebabble for aws_lb. (terraform v0.12.0 A name must start with a letter or underscore)
