### PR TITLE
added condition to check if resource name begins with letter

### DIFF
--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -36,14 +36,9 @@ module Terrafying
           instance_profile: nil,
           ports: [],
           tags: {},
-          security_groups: nil,
           metadata_options: nil,
-          depends_on: nil,
-          ipv6_cidr_blocks: nil,
-          prefix_list_ids: nil,
-          security_groups: nil,
-          self: nil,
-          description: nil,
+          security_groups: [],
+          depends_on: []
         }.merge(options)
 
         ident = "#{tf_safe(vpc.name)}-#{name}"
@@ -62,11 +57,11 @@ module Terrafying
                                        to_port: 0,
                                        protocol: -1,
                                        cidr_blocks: ['0.0.0.0/0'],
-                                       ipv6_cidr_blocks: options[:ipv6_cidr_blocks],
-                                       prefix_list_ids: options[:prefix_list_ids],
-                                       security_groups: options[:security_groups],
-                                       self: options[:self],
-                                       description: options[:description]
+                                       ipv6_cidr_blocks: nil,
+                                       prefix_list_ids: nil,
+                                       security_groups: nil,
+                                       self: nil,
+                                       description: nil
                                      }
                                    ]
 

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -3,7 +3,7 @@
 require 'digest/bubblebabble'
 require 'terrafying/components/usable'
 require 'terrafying/generator'
-
+require 'digest'
 require_relative './ports'
 
 module Terrafying
@@ -216,9 +216,14 @@ module Terrafying
       end
 
       def make_identifier(type, vpc_name, name)
-        gen_id = "#{type}-#{tf_safe(vpc_name)}-#{name}"
-        return Digest::SHA256.bubblebabble(gen_id)[0..15] if @hex_ident || gen_id.size > 26
 
+        gen_id = "#{type}-#{vpc_name}-#{name}"
+        hex = Digest::SHA2.hexdigest(gen_id)[0..24]
+        if hex[0..0] =~ /[a-z]/
+            return hex if @hex_ident || gen_id.size > 26
+        else return Digest::SHA256.bubblebabble(gen_id)[0..15]
+          end
+    
         gen_id[0..31]
       end
     end

--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -294,7 +294,7 @@ module Terrafying
         route_tables.product(cidrs).each do |route_table, cidr|
           hash = Digest::SHA2.hexdigest "#{route_table}-#{tf_safe(cidr)}"
 
-          resource :aws_route, "#{@name}-to-#{ident}-peer-#{hash}",
+          resource :aws_route, "#{@name}-to-#{tf_safe(ip_address)}-peer-#{hash}",
                    route_table_id: route_table,
                    destination_cidr_block: cidr,
                    gateway_id: vpn_gateway


### PR DESCRIPTION
changed load balancer hex check to see if it begins with a letter. if it does not then it will replace the resource name using babble.
security group changes where options where not required.
aws route resource name corrected to still include IP address as this should not change