### PR TITLE
Update flatcar base image

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -33,7 +33,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-3c48f829', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
           instance_type: 't3a.micro',
           instances: { min: 1, max: 1, desired: 1, tags: {} },
           ports: [],

--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -33,7 +33,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-2860fb52', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['136393635417']),
           instance_type: 't3a.micro',
           instances: { min: 1, max: 1, desired: 1, tags: {} },
           ports: [],

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -41,7 +41,7 @@ module Terrafying
 
       def create_in(vpc, name, options = {})
         options = {
-          ami: aws.ami('base-image-fc-2860fb52', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['136393635417']),
           instance_type: 't3a.micro',
           ports: [],
           instances: [{}],

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -41,7 +41,7 @@ module Terrafying
 
       def create_in(vpc, name, options = {})
         options = {
-          ami: aws.ami('base-image-fc-3c48f829', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
           instance_type: 't3a.micro',
           ports: [],
           instances: [{}],

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -38,7 +38,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-3c48f829', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
           instance_type: 't3a.micro',
           subnets: vpc.subnets.fetch(:private, []),
           ports: [],

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -38,7 +38,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-2860fb52', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['136393635417']),
           instance_type: 't3a.micro',
           subnets: vpc.subnets.fetch(:private, []),
           ports: [],


### PR DESCRIPTION
As we have updated the base image which fixes the CVE as mentioned here:
https://www.flatcar-linux.org/releases/#release-2512.4.0, This PR
updates respective base image references.