### PR TITLE
Update flatcar base image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ pipeline:
       - rake push
     when:
       event: tag
-      branch: master
+      # branch: master
 
   docker-tag:
     image: plugins/docker
@@ -45,4 +45,4 @@ pipeline:
     auto_tag: true
     when:
       event: tag
-      branch: master
+      # branch: master

--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -33,7 +33,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-2860fb52', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
           instance_type: 't3a.micro',
           instances: { min: 1, max: 1, desired: 1, tags: {} },
           ports: [],

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -41,7 +41,7 @@ module Terrafying
 
       def create_in(vpc, name, options = {})
         options = {
-          ami: aws.ami('base-image-fc-2860fb52', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
           instance_type: 't3a.micro',
           ports: [],
           instances: [{}],

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -38,7 +38,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-2860fb52', owners = ['136393635417']),
+          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
           instance_type: 't3a.micro',
           subnets: vpc.subnets.fetch(:private, []),
           ports: [],


### PR DESCRIPTION
* this branch is created from tag [1.15.21](https://github.com/uswitch/terrafying-components/releases/tag/1.15.21)
* As we have updated the base image which fixes the CVE as mentioned here:
https://www.flatcar-linux.org/releases/#release-2512.4.0, This PR
updates respective base image references.

* updating drone to release tag version even if branch is not master,
because we would like to release terrafying-components from this branch
itself.

* once PR is approved, I'll release the new tag and close this PR and
preserve this branch for future updates to 1.x