### PR TITLE
correct empty value for metadata so it becomes null as default

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -44,7 +44,7 @@ module Terrafying
           subnets: vpc.subnets.fetch(:private, []),
           depends_on: [],
           rolling_update: :simple,
-          metadata_options: {},
+          metadata_options: nil,
           vpc_endpoints_egress: []
         }.merge(options)
 

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -59,7 +59,7 @@ module Terrafying
           subnets: vpc.subnets.fetch(:private, []),
           startup_grace_period: 300,
           depends_on: [],
-          metadata_options: {},
+          metadata_options: nil,
           audit_role: "arn:aws:iam::#{aws.account_id}:role/auditd_logging",
           metrics_ports: [],
           vpc_endpoints_egress: []


### PR DESCRIPTION
currently this show an empty value, terraform requires at least `null` to compute.