### PR TITLE
Give proper defaults and remove nil values

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -48,8 +48,6 @@ module Terrafying
           vpc_endpoints_egress: []
         }.merge(options)
 
-        metadata_options = options[:metadata_options]
-
         ident = "#{tf_safe(vpc.name)}-#{name}"
 
         @name = ident
@@ -70,7 +68,7 @@ module Terrafying
 
         path_mtu_setup!
 
-        launch_config = resource :aws_launch_configuration, ident,
+        launch_config = resource :aws_launch_configuration, ident, {
                                  name_prefix: "#{ident}-",
                                  image_id: options[:ami],
                                  instance_type: options[:instance_type],
@@ -90,6 +88,7 @@ module Terrafying
                                  },
                                  metadata_options: options[:metadata_options],
                                  depends_on: resource_name_from(options[:instance_profile])
+                                }.compact
 
         if options[:instances][:track]
           instances = instances_by_tags(Name: ident)

--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -110,7 +110,7 @@ module Terrafying
             create_before_destroy: true
           },
           depends_on: options[:depends_on]
-        }.merge(options[:ip_address] ? { private_ip: options[:ip_address] } : {}).merge(lifecycle)
+        }.merge(options[:ip_address] ? { private_ip: options[:ip_address] } : {}).merge(lifecycle).compact
 
         @ip_address = @id[options[:public] ? :public_ip : :private_ip]
 

--- a/lib/terrafying/components/instance.rb
+++ b/lib/terrafying/components/instance.rb
@@ -57,11 +57,11 @@ module Terrafying
                                        to_port: 0,
                                        protocol: -1,
                                        cidr_blocks: ['0.0.0.0/0'],
-                                       ipv6_cidr_blocks: nil,
-                                       prefix_list_ids: nil,
-                                       security_groups: nil,
+                                       ipv6_cidr_blocks: [],
+                                       prefix_list_ids: [],
+                                       security_groups: [],
                                        self: nil,
-                                       description: nil
+                                       description: ''
                                      }
                                    ]
 

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -97,8 +97,6 @@ module Terrafying
           @instance_profile = add! InstanceProfile.create(ident, statements: iam_statements)
         end
 
-        metadata_options = options[:metadata_options]
-
         tags = options[:tags].merge(service_name: name)
 
         set = options[:instances].is_a?(Hash) ? DynamicSet : StaticSet
@@ -115,7 +113,7 @@ module Terrafying
         instance_set_options = {
           instance_profile: @instance_profile,
           depends_on: depends_on,
-          metadata_options: metadata_options,
+          metadata_options: options[:metadata_options],
           tags: tags
         }
 

--- a/lib/terrafying/components/vpc.rb
+++ b/lib/terrafying/components/vpc.rb
@@ -186,10 +186,10 @@ module Terrafying
                                                     to_port: 22,
                                                     protocol: 'tcp',
                                                     cidr_blocks: [@cidr],
-                                                    description: nil, 
-                                                    ipv6_cidr_blocks: nil, 
-                                                    prefix_list_ids: nil, 
-                                                    security_groups: nil,
+                                                    description: '',
+                                                    ipv6_cidr_blocks: [],
+                                                    prefix_list_ids: [],
+                                                    security_groups: [],
                                                     self: nil
                                                   }
                                                 ],
@@ -199,10 +199,10 @@ module Terrafying
                                                     to_port: 22,
                                                     protocol: 'tcp',
                                                     cidr_blocks: [@cidr],
-                                                    description: nil, 
-                                                    ipv6_cidr_blocks: nil, 
-                                                    prefix_list_ids: nil, 
-                                                    security_groups: nil,
+                                                    description: '',
+                                                    ipv6_cidr_blocks: [],
+                                                    prefix_list_ids: [],
+                                                    security_groups: [],
                                                     self: nil
                                                   }
                                                 ]

--- a/spec/terrafying/components/vpc_spec.rb
+++ b/spec/terrafying/components/vpc_spec.rb
@@ -162,10 +162,10 @@ end
       to_port: 22,
       protocol: 'tcp',
       cidr_blocks: [cidr],
-      description: nil, 
-      ipv6_cidr_blocks: nil, 
-      prefix_list_ids: nil, 
-      security_groups: nil,
+      description: '',
+      ipv6_cidr_blocks: [],
+      prefix_list_ids: [],
+      security_groups: [],
       self: nil
     }
 


### PR DESCRIPTION
Broken - https://ci.usw.co/uswitch/terrafying-cloud/1723/4

Currently terrafying-components >1.21 is broken for Terraform 11.

The attributes `ipv6_cidr_blocks`, `prefix_list_ids`, `security_groups`, `self` and `description` are all optional in the AWS Terraform Provider docs but due to some changes in Terraform v12, they now need to be set if using JSON - https://github.com/hashicorp/terraform/issues/23347.

Have given them empty values instead of nil. Left self as nil as this was a boolean value.

Using .compact on launch configuration so that the metadata_option is removed if it is nil.