### PR TITLE
Remove nil values for security config aggregator

### DIFF
--- a/lib/terrafying/components/security/config_aggregator.rb
+++ b/lib/terrafying/components/security/config_aggregator.rb
@@ -42,7 +42,7 @@ module Terrafying
                      provider: @provider,
                      role: role["name"],
                      policy_arn: "arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations",
-                   }
+                  }.compact
 
           source = {}
 


### PR DESCRIPTION
This is the case for the provider not defined here - https://github.com/uswitch/terrafying-cloud/blob/master/specs/baseline.rb#L73, and causes errors when using Terraform 12 - https://ci.usw.co/uswitch/terrafying-cloud/1729/4

`Role` and `PolicyArn` are required so will correctly error if they are nil anyway