### PR TITLE
Fix security groups with inline rules

### DIFF
--- a/lib/terrafying/components/vpn.rb
+++ b/lib/terrafying/components/vpn.rb
@@ -134,7 +134,12 @@ module Terrafying
             from_port: 0,
             to_port: 0,
             protocol: -1,
-            security_groups: [@service.egress_security_group]
+            security_groups: [@service.egress_security_group],
+            ipv6_cidr_blocks: nil,
+            prefix_list_ids: nil,
+            cidr_blocks: nil,
+            self: nil,
+            description: nil
           }
         ]
 
@@ -143,7 +148,12 @@ module Terrafying
             from_port: 0,
             to_port: 0,
             protocol: -1,
-            cidr_blocks: ["#{@ip_address}/32"]
+            cidr_blocks: ["#{@ip_address}/32"],
+            ipv6_cidr_blocks: nil,
+            prefix_list_ids: nil,
+            security_groups: nil,
+            self: nil,
+            description: nil
           }
         end
 

--- a/lib/terrafying/components/vpn_oidc.rb
+++ b/lib/terrafying/components/vpn_oidc.rb
@@ -134,7 +134,12 @@ module Terrafying
             from_port: 0,
             to_port: 0,
             protocol: -1,
-            security_groups: [@service.egress_security_group]
+            security_groups: [@service.egress_security_group],
+            ipv6_cidr_blocks: nil,
+            prefix_list_ids: nil,
+            cidr_blocks: nil,
+            self: nil,
+            description: nil,
           }
         ]
 
@@ -143,7 +148,12 @@ module Terrafying
             from_port: 0,
             to_port: 0,
             protocol: -1,
-            cidr_blocks: ["#{@ip_address}/32"]
+            cidr_blocks: ["#{@ip_address}/32"],
+            ipv6_cidr_blocks: nil,
+            prefix_list_ids: nil,
+            security_groups: nil,
+            self: nil,
+            description: nil
           }
         end
 


### PR DESCRIPTION
In Terraform 12, when using JSON, for some attributes, you need to define all the attributes even if they are technically `optionally` in the docs.

https://github.com/hashicorp/terraform/issues/23347.

Nil gets converted to null and null equates to unset value - https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements

If there is a way to add these values in the repos that use Terrafying Components, please let me know.