### PR TITLE
Changes for Terraform 12 and AWS Provider > 3.0.0

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -163,7 +163,7 @@ module Terrafying
 
       def attach_load_balancer(load_balancer)
         load_balancer.targets.each.with_index do |target, i|
-          resource :aws_autoscaling_attachment, "#{load_balancer.name}-#{@name}-#{i}",
+          resource :aws_autoscaling_attachment, "#{load_balancer.name}-#{@name}-#{i}".gsub(%r{^(\d)}, '_\1'),
                    autoscaling_group_name: @asg,
                    alb_target_group_arn: target.target_group
         end

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'digest/bubblebabble'
 require 'terrafying/components/usable'
 require 'terrafying/generator'
 require 'digest'
@@ -36,14 +35,15 @@ module Terrafying
         rescue StandardError
           @type = 'application'
           ident = make_identifier(@type, vpc.name, name)
+          name = make_name(@type, vpc.name, name)
 
-          lb = aws.lb_by_name(ident)
+          lb = aws.lb_by_name(name)
 
-          @security_group = aws.security_group_by_tags(loadbalancer_name: ident)
+          @security_group = aws.security_group_by_tags(loadbalancer_name: name)
         end
 
         @id = lb.load_balancer_arn
-        @name = ident
+        @name = name
 
         target_groups = aws.target_groups_by_lb(@id)
 
@@ -93,14 +93,14 @@ module Terrafying
         @type = l4_ports.count == 0 ? 'application' : 'network'
 
         ident = make_identifier(@type, vpc.name, name)
-        @name = ident
+        @name = make_name(@type, vpc.name, name)
 
         if application?
           @security_group = resource :aws_security_group, ident,
-                                     name: "loadbalancer-#{ident}",
-                                     description: "Describe the ingress and egress of the load balancer #{ident}",
+                                     name: "loadbalancer-#{@name}",
+                                     description: "Describe the ingress and egress of the load balancer #{@name}",
                                      tags: @tags.merge(
-                                       loadbalancer_name: ident
+                                       loadbalancer_name: @name
                                      ),
                                      vpc_id: vpc.id
 
@@ -112,7 +112,7 @@ module Terrafying
         end
 
         @id = resource :aws_lb, ident, {
-          name: ident,
+          name: @name,
           load_balancer_type: type,
           internal: !options[:public],
           tags: @tags
@@ -125,8 +125,9 @@ module Terrafying
 
         @ports.each do |port|
           port_ident = "#{ident}-#{port[:downstream_port]}"
+          port_name = "#{@name}-#{port[:downstream_port]}"
 
-          default_action = port.key?(:action) ? port[:action] : forward_to_tg(port, port_ident, vpc)
+          default_action = port.key?(:action) ? port[:action] : forward_to_tg(port, port_ident, port_name, vpc)
 
           ssl_options = alb_certs(port, port_ident)
 
@@ -148,9 +149,9 @@ module Terrafying
         self
       end
 
-      def forward_to_tg(port, port_ident, vpc)
+      def forward_to_tg(port, port_ident, port_name, vpc)
         target_group = resource :aws_lb_target_group, port_ident, {
-          name: port_ident,
+          name: port_name,
           port: port[:downstream_port],
           protocol: port[:type].upcase,
           vpc_id: vpc.id
@@ -215,16 +216,15 @@ module Terrafying
         set.autoscale_on_load_balancer(self, target_value: target_value, disable_scale_in: disable_scale_in)
       end
 
-      def make_identifier(type, vpc_name, name)
+      def make_name(type, vpc_name, name)
+        gen_id = "#{type}-#{tf_safe(vpc_name)}-#{name}"
+        return Digest::SHA2.hexdigest(gen_id)[0..24] if @hex_ident || gen_id.size > 26
 
-        gen_id = "#{type}-#{vpc_name}-#{name}"
-        hex = Digest::SHA2.hexdigest(gen_id)[0..24]
-        if hex[0..0] =~ /[a-z]/
-            return hex if @hex_ident || gen_id.size > 26
-        else return Digest::SHA256.bubblebabble(gen_id)[0..15]
-          end
-    
         gen_id[0..31]
+      end
+
+      def make_identifier(type, vpc_name, name)
+        make_name(type, vpc_name, name).gsub(%r{^(\d)}, '_\1')
       end
     end
   end

--- a/lib/terrafying/components/security/trail.rb
+++ b/lib/terrafying/components/security/trail.rb
@@ -120,7 +120,7 @@ module Terrafying
                                                "logs:CreateLogStream"
                                              ],
                                              Resource: [
-                                               @log_group["arn"],
+                                               "#{@log_group["arn"]}:*",
                                              ]
                                            },
                                            {
@@ -130,7 +130,7 @@ module Terrafying
                                                "logs:PutLogEvents"
                                              ],
                                              Resource: [
-                                               @log_group["arn"],
+                                               "#{@log_group["arn"]}:*",
                                              ]
                                            }
                                          ]
@@ -152,7 +152,7 @@ module Terrafying
                      enable_log_file_validation: true,
                      kms_key_id: store.key_arn,
 
-                     cloud_watch_logs_group_arn: @log_group["arn"],
+                     cloud_watch_logs_group_arn: "#{@log_group["arn"]}:*",
                      cloud_watch_logs_role_arn: log_role["arn"],
 
                      event_selector: [

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -161,7 +161,7 @@ module Terrafying
 
       def attach_load_balancer(load_balancer)
         @instances.product(load_balancer.targets).each.with_index do |(instance, target), i|
-          resource :aws_lb_target_group_attachment, "#{load_balancer.name}-#{@name}-#{i}",
+          resource :aws_lb_target_group_attachment, "#{load_balancer.name}-#{@name}-#{i}".gsub(%r{^(\d)}, '_\1'),
                    target_group_arn: target.target_group,
                    target_id: instance.id
         end

--- a/lib/terrafying/components/usable.rb
+++ b/lib/terrafying/components/usable.rb
@@ -16,7 +16,7 @@ module Terrafying
       end
 
       def path_mtu_setup!
-        resource :aws_security_group_rule, "#{@name}-path-mtu",
+        resource :aws_security_group_rule, "#{@name}-path-mtu".gsub(%r{^(\d)}, '_\1'),
                  security_group_id: egress_security_group,
                  type: 'ingress',
                  protocol: 1, # icmp
@@ -42,7 +42,7 @@ module Terrafying
           cidr_ident = cidr.tr('./', '-')
 
           @ports.select(&block).map do |port|
-            resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}",
+            resource :aws_security_group_rule, "#{@name}-to-#{cidr_ident}-#{port[:name]}".gsub(%r{^(\d)}, '_\1'),
                      security_group_id: ingress_security_group,
                      type: 'ingress',
                      from_port: from_port(port[:upstream_port]),
@@ -92,7 +92,7 @@ module Terrafying
       def used_by(*other_resources, &block)
         other_resources.map do |other_resource|
           @ports.select(&block).map.map do |port|
-            resource :aws_security_group_rule, "#{@name}-to-#{other_resource.name}-#{port[:name]}",
+            resource :aws_security_group_rule, "#{@name}-to-#{other_resource.name}-#{port[:name]}".gsub(%r{^(\d)}, '_\1'),
                      security_group_id: ingress_security_group,
                      type: 'ingress',
                      from_port: from_port(port[:upstream_port]),
@@ -100,7 +100,7 @@ module Terrafying
                      protocol: port[:type] == 'udp' ? 'udp' : 'tcp',
                      source_security_group_id: other_resource.egress_security_group
 
-            resource :aws_security_group_rule, "#{other_resource.name}-to-#{@name}-#{port[:name]}",
+            resource :aws_security_group_rule, "#{other_resource.name}-to-#{@name}-#{port[:name]}".gsub(%r{^(\d)}, '_\1'),
                      security_group_id: other_resource.egress_security_group,
                      type: 'egress',
                      from_port: from_port(port[:downstream_port]),

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -91,15 +91,19 @@ RSpec.describe Terrafying::Components::LoadBalancer do
     expect(lb.name.length).to be <= 32
   end
 
-  it 'should use bubblebabble identifiers when requested' do
+  it 'should use bubblebabble identifiers when requested but keep hexdigest for name' do
     name = 'abcde-fghi-jklm'
-    expected_bubblebabble = Digest::SHA256.bubblebabble("application-#{@vpc.name}-#{name}")[0..15]
+    expect_name = Digest::SHA2.hexdigest("application-#{@vpc.name}-#{name}")[0..24]
 
     lb = Terrafying::Components::LoadBalancer.create_in(
       @vpc, name, hex_ident: true
     )
 
-    expect(lb.name).to eq(expected_bubblebabble)
+    lb_resource_name = lb.output_with_children['resource']['aws_lb'].keys.first
+    lb_resource = lb.output_with_children['resource']['aws_lb'].values.first
+
+    expect(lb_resource_name).to eq(expect_name.gsub(%r{^(\d)}, '_\1'))
+    expect(lb.name).to eq(expect_name)
   end
 
   context('application load balancer') do


### PR DESCRIPTION
As of AWS Terraform Provider 3.0.0 they have trimmed `:*` from log_group arns so these need to be added manually - [AWS Terraform Provider PR](https://github.com/hashicorp/terraform-provider-aws/pull/14214)

Resource identifiers can't start with numbers so have added a `_` to resources if this happens

We used identifier as the `name` for some resources. As we changed the identifier, this also changes the name. Changing the name of a load balancer results in resources getting recreated.

