### PR TITLE
Add ability to have multiple default_actions for aws_lb_listener

### DIFF
--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -127,7 +127,12 @@ module Terrafying
           port_ident = "#{ident}-#{port[:downstream_port]}"
           port_name = "#{@name}-#{port[:downstream_port]}"
 
+          actions = []
+
           default_action = port.key?(:action) ? port[:action] : forward_to_tg(port, port_ident, port_name, vpc)
+          actions.append(default_action)
+
+          port.key?(:oidc_config) ? actions.append(authenticate_oidc(port[:oidc_config])) : nil
 
           ssl_options = alb_certs(port, port_ident)
 
@@ -135,7 +140,7 @@ module Terrafying
             load_balancer_arn: @id,
             port: port[:upstream_port],
             protocol: port[:type].upcase,
-            default_action: default_action
+            default_action: actions
           }.merge(ssl_options)
 
           register_target(default_action[:target_group_arn], listener) if default_action[:type] == 'forward'
@@ -162,6 +167,14 @@ module Terrafying
           target_group_arn: target_group
         }
       end
+
+      def authenticate_oidc(oidc_config)
+        {
+          type: "authenticate-oidc",
+          authenticate_oidc: oidc_config
+        }
+      end
+
 
       def register_target(target_group, listener)
         @targets << Struct::Target.new(

--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -130,9 +130,9 @@ module Terrafying
           actions = []
 
           default_action = port.key?(:action) ? port[:action] : forward_to_tg(port, port_ident, port_name, vpc)
-          actions.append(default_action)
 
-          port.key?(:oidc_config) ? actions.append(authenticate_oidc(port[:oidc_config])) : nil
+          actions.append(default_action)
+          actions.append(authenticate_oidc(port[:oidc_config])) if !port[:oidc_config].nil?
 
           ssl_options = alb_certs(port, port_ident)
 
@@ -174,7 +174,6 @@ module Terrafying
           authenticate_oidc: oidc_config
         }
       end
-
 
       def register_target(target_group, listener)
         @targets << Struct::Target.new(


### PR DESCRIPTION
This will enable us to use the authenticate-oidc action - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener#authenticate-oidc-action