### PR TITLE
Changes to identifiers to allow terrafying-envoy to migrate to tf12

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -173,13 +173,14 @@ module Terrafying
 
       def autoscale_on_load_balancer(load_balancer, target_value:, disable_scale_in:)
         load_balancer.targets.each.with_index do |target, i|
+          policy_ident = "#{load_balancer.name}-#{@name}-#{i}".gsub(%r{^(\d)}, '_\1')
           policy_name = "#{load_balancer.name}-#{@name}-#{i}"
           lb_arn = load_balancer.id.to_s.gsub(/id/, 'arn_suffix')
           tg_arn = target.target_group.to_s.gsub(/id/, 'arn_suffix')
           listener = "aws_lb_listener.#{target.listener.to_s.split('.')[1]}"
-          autoscaling_attachment = "aws_autoscaling_attachment.#{policy_name}"
+          autoscaling_attachment = "aws_autoscaling_attachment.#{policy_ident}"
 
-          resource :aws_autoscaling_policy, policy_name,
+          resource :aws_autoscaling_policy, policy_ident,
                    name: policy_name,
                    autoscaling_group_name: @asg,
                    policy_type: 'TargetTrackingScaling',

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -170,7 +170,7 @@ module Terrafying
         prom = Prometheus.find_in(vpc: vpc)
         ports.each do |port|
           sg_rule_ident = Digest::SHA256.hexdigest("#{vpc.name}-#{port}-#{security_group}-#{prom.security_group}")
-          resource :aws_security_group_rule, sg_rule_ident,
+          resource :aws_security_group_rule, sg_rule_ident.gsub(%r{^(\d)}, '_\1'),
                    security_group_id: security_group,
                    type: 'ingress',
                    from_port: port,


### PR DESCRIPTION
These are the same changes that were added to version 1
- https://github.com/uswitch/terrafying-components/commit/b94595deb9d46c831ad5360c31eb0497585c34d5
- https://github.com/uswitch/terrafying-components/commit/cccfa0785f12b4ece4526de91a70b415c9e30cae