### PR TITLE
Add metric alarm, topic + sub for certbot lambdas

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -324,7 +324,7 @@ module Terrafying
               )
             }
 
-        lamda_function = resource :aws_lambda_function, "#{@name}_lambda", {
+        lambda_function = resource :aws_lambda_function, "#{@name}_lambda", {
           function_name: "#{@name}_lambda",
           s3_bucket: "uswitch-certbot-lambda",
           s3_key: "certbot-lambda.zip",
@@ -355,14 +355,14 @@ module Terrafying
 
         resource :aws_cloudwatch_event_target, "#{@name}_lambda_event_target", {
           rule: event_rule["name"],
-          target_id: lamda_function["id"],
-          arn: lamda_function["arn"]
+          target_id: lambda_function["id"],
+          arn: lambda_function["arn"]
         }
 
         resource :aws_lambda_permission, "allow_cloudwatch_to_invoke_#{@name}_lambda", {
           statement_id: "AllowExecutionFromCloudWatch",
           action: "lambda:InvokeFunction",
-          function_name: lamda_function["function_name"],
+          function_name: lambda_function["function_name"],
           principal: "events.amazonaws.com",
           source_arn: event_rule["arn"]
         }

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -47,7 +47,8 @@ module Terrafying
           curve: 'P384',
           rsa_bits: '3072',
           use_external_dns: false,
-          renewing: false
+          renewing: false,
+          renew_alert_endpoint: ""
         }.merge(options)
 
         @name = name
@@ -56,6 +57,7 @@ module Terrafying
         @acme_provider = @acme_providers[options[:provider]]
         @use_external_dns = options[:use_external_dns]
         @renewing = options[:renewing]
+        @renew_alert_endpoint = options[:renew_alert_endpoint]
         @prefix_path = [@prefix, @name].reject(&:empty?).join("/")
 
         renew() if @renewing
@@ -393,7 +395,7 @@ module Terrafying
         resource :aws_sns_topic_subscription, "#{@name}_lambda_cloudwatch_subscription",
                  topic_arn: "${aws_sns_topic.#{@name}_lambda_cloudwatch_topic.arn}",
                  protocol: "https",
-                 endpoint: "",
+                 endpoint: @renew_alert_endpoint,
                  endpoint_auto_confirms: true
 
         self

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -48,7 +48,9 @@ module Terrafying
           rsa_bits: '3072',
           use_external_dns: false,
           renewing: false,
-          renew_alert_endpoint: ""
+          renew_alert_protocol: "",
+          renew_alert_endpoint: "",
+          renew_alert_endpoint_auto_confirms: false
         }.merge(options)
 
         @name = name
@@ -57,7 +59,9 @@ module Terrafying
         @acme_provider = @acme_providers[options[:provider]]
         @use_external_dns = options[:use_external_dns]
         @renewing = options[:renewing]
+        @renew_alert_protocol = options[:renew_alert_protocol]
         @renew_alert_endpoint = options[:renew_alert_endpoint]
+        @renew_alert_endpoint_auto_confirms = options[:renew_alert_endpoint_auto_confirms]
         @prefix_path = [@prefix, @name].reject(&:empty?).join("/")
 
         renew() if @renewing
@@ -394,9 +398,9 @@ module Terrafying
 
         resource :aws_sns_topic_subscription, "#{@name}_lambda_cloudwatch_subscription",
                  topic_arn: "${aws_sns_topic.#{@name}_lambda_cloudwatch_topic.arn}",
-                 protocol: "https",
+                 protocol: @renew_alert_protocol,
                  endpoint: @renew_alert_endpoint,
-                 endpoint_auto_confirms: true
+                 endpoint_auto_confirms: @renew_alert_endpoint_auto_confirms
 
         self
       end

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -49,13 +49,13 @@ module Terrafying
           use_external_dns: false,
           renewing: false,
           renew_alert_options: {
-            protocol: "",
-            endpoint: "",
+            protocol: nil,
+            endpoint: nil,
             endpoint_auto_confirms: false,
             confirmation_timeout_in_minutes: 1,
             raw_message_delivery: false,
-            filter_policy: "",
-            delivery_policy: ""
+            filter_policy: nil,
+            delivery_policy: nil
           }
         }.merge(options)
 
@@ -409,7 +409,7 @@ module Terrafying
                  raw_message_delivery: @renew_alert_options[:raw_message_delivery],
                  filter_policy: @renew_alert_options[:filter_policy],
                  delivery_policy: @renew_alert_options[:delivery_policy]
-                 
+
         self
       end
 

--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -48,9 +48,15 @@ module Terrafying
           rsa_bits: '3072',
           use_external_dns: false,
           renewing: false,
-          renew_alert_protocol: "",
-          renew_alert_endpoint: "",
-          renew_alert_endpoint_auto_confirms: false
+          renew_alert_options: {
+            protocol: "",
+            endpoint: "",
+            endpoint_auto_confirms: false,
+            confirmation_timeout_in_minutes: 1,
+            raw_message_delivery: false,
+            filter_policy: "",
+            delivery_policy: ""
+          }
         }.merge(options)
 
         @name = name
@@ -59,9 +65,7 @@ module Terrafying
         @acme_provider = @acme_providers[options[:provider]]
         @use_external_dns = options[:use_external_dns]
         @renewing = options[:renewing]
-        @renew_alert_protocol = options[:renew_alert_protocol]
-        @renew_alert_endpoint = options[:renew_alert_endpoint]
-        @renew_alert_endpoint_auto_confirms = options[:renew_alert_endpoint_auto_confirms]
+        @renew_alert_options = options[:renew_alert_options]
         @prefix_path = [@prefix, @name].reject(&:empty?).join("/")
 
         renew() if @renewing
@@ -398,10 +402,14 @@ module Terrafying
 
         resource :aws_sns_topic_subscription, "#{@name}_lambda_cloudwatch_subscription",
                  topic_arn: "${aws_sns_topic.#{@name}_lambda_cloudwatch_topic.arn}",
-                 protocol: @renew_alert_protocol,
-                 endpoint: @renew_alert_endpoint,
-                 endpoint_auto_confirms: @renew_alert_endpoint_auto_confirms
-
+                 protocol: @renew_alert_options[:protocol],
+                 endpoint: @renew_alert_options[:endpoint],
+                 endpoint_auto_confirms: @renew_alert_options[:endpoint_auto_confirms],
+                 confirmation_timeout_in_minutes: @renew_alert_options[:confirmation_timeout_in_minutes],
+                 raw_message_delivery: @renew_alert_options[:raw_message_delivery],
+                 filter_policy: @renew_alert_options[:filter_policy],
+                 delivery_policy: @renew_alert_options[:delivery_policy]
+                 
         self
       end
 


### PR DESCRIPTION
Adds cloudwatch metric alarm with sns topic and subscription for certbot lambdas. 

Topic pushes notifications to a specified endpoint, example of intended usage:
```
add! Terrafying::Components::LetsEncrypt.create(
            "name", "bucket",
            curve: "P256",
            rsa_bits: "2048",
            provider: :live,
            renewing: true,
            renew_alert_options: {
                protocol: "https"
                endpoint: "https://my.alert.service/key",
                endpoint_auto_confirms: true
            }
          )
```

default values set as per: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription