### PR TITLE
Add statistic to cw alarm

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -393,6 +393,7 @@ module Terrafying
                  metric_name: "Errors",
                  namespace: "AWS/Lambda",
                  threshold: 1,
+                 statistic: "Maximum",
                  alarm_description: "Alert generated if the #{@name} certbot lambda fails execution",
                  actions_enabled: true,
                  dimensions: {


### PR DESCRIPTION
```Error: One of `statistic` or `extended_statistic` must be set for a cloudwatch metric alarm```

Docs specify that you can't specify both (have to use one or the other) but does not explicity state that one MUST be specified and they're both listed as optional :)