### PR TITLE
Change order of actions

### DIFF
--- a/lib/terrafying/components/loadbalancer.rb
+++ b/lib/terrafying/components/loadbalancer.rb
@@ -131,8 +131,8 @@ module Terrafying
 
           default_action = port.key?(:action) ? port[:action] : forward_to_tg(port, port_ident, port_name, vpc)
 
-          actions.append(default_action)
           actions.append(authenticate_oidc(port[:oidc_config])) if !port[:oidc_config].nil?
+          actions.append(default_action)
 
           ssl_options = alb_certs(port, port_ident)
 

--- a/spec/terrafying/components/loadbalancer_spec.rb
+++ b/spec/terrafying/components/loadbalancer_spec.rb
@@ -169,11 +169,11 @@ RSpec.describe Terrafying::Components::LoadBalancer do
 
       expect(listener_actions.length() == 2)
 
-      expect(listener_actions.first[:type] == "forward")
+      expect(listener_actions.first[:type] == "authenticate-oidc")
+      expect(listener_actions.first[:authenticate_oidc][:client_id] ==  "client_id")
+      expect(listener_actions.first[:authenticate_oidc][:client_secret] ==  "client_secret") 
 
-      expect(listener_actions.last[:type] == "authenticate-oidc")
-      expect(listener_actions.last[:authenticate_oidc][:client_id] ==  "client_id")
-      expect(listener_actions.last[:authenticate_oidc][:client_secret] ==  "client_secret")
+      expect(listener_actions.last[:type] == "forward")
     end
 
     context('ssl certificates') do


### PR DESCRIPTION
Due to error `An action of type 'forward' must have a higher order than all other actions` in build https://ci.usw.co/uswitch/terrafying-envoy/1224/4

Running Terraform locally worked with this change