### PR TITLE
Use latest base image

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -33,7 +33,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
+          ami: aws.ami('base-image-fc-b4b2c239', owners = ['477284023816']),
           instance_type: 't3a.micro',
           instances: { min: 1, max: 1, desired: 1, tags: {} },
           ports: [],
@@ -142,7 +142,7 @@ module Terrafying
                  protocol: -1,
                  prefix_list_ids: prefix_ids
       end
-      
+
       def default_egress_rule(ident, security_group)
         resource :aws_security_group_rule, "#{ident}-default-egress",
                  security_group_id: security_group,

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -41,7 +41,7 @@ module Terrafying
 
       def create_in(vpc, name, options = {})
         options = {
-          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
+          ami: aws.ami('base-image-fc-b4b2c239', owners = ['477284023816']),
           instance_type: 't3a.micro',
           ports: [],
           instances: [{}],

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -38,7 +38,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-3c48f829', owners = ['477284023816']),
+          ami: aws.ami('base-image-fc-b4b2c239', owners = ['477284023816']),
           instance_type: 't3a.micro',
           subnets: vpc.subnets.fetch(:private, []),
           ports: [],


### PR DESCRIPTION
This newer AMI pulls in Flatcar-stable-2605.12.0-hvm which includes the fix for CVE-2021-3156