### PR TITLE
Use TF 0.12.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6.3-alpine3.9
 
 ARG TERRAFYING_VERSION=0.0.0
-ENV TERRAFORM_VERSION=0.11.14
+ENV TERRAFORM_VERSION=0.12.29
 
 RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
  && unzip terraform.zip \


### PR DESCRIPTION
This bumps the version of terraform installed in the terrafying-components container to 0.12.29. 

This is required in some projects which use the terrafying-components container to plan/apply terraform resources, which will have already been upgraded to use TF 0.12.x as part of the requirements for using terrafying-components 2.x