### PR TITLE
Make sure LB identifier is correct

### DIFF
--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -377,7 +377,7 @@ module Terrafying
       def create_thanos_cloudwatch_alert(service)
         service.load_balancer.targets.each_with_index do |target, i|
           cloudwatch_alarm "#{service.name}_#{i}", 'AWS/NetworkELB',
-                           LoadBalancer: output_of('aws_lb', service.load_balancer.name, 'arn_suffix'),
+                           LoadBalancer: output_of('aws_lb', service.load_balancer.name.gsub(%r{^(\d)}, '_\1'), 'arn_suffix'),
                            TargetGroup: target.target_group.to_s.gsub(/id/, 'arn_suffix')
         end
       end


### PR DESCRIPTION
From [this PR](https://github.com/uswitch/terrafying-components/pull/193), when using terrafying-components 2.x, the identifier is the same as the name but with an underscore in front if it starts with the number.

It causes an error as seen [here](https://ci.usw.co/uswitch/vault-test-environment/2777/4) but was fixed with the added change, see plan [here](https://ci.usw.co/uswitch/vault-test-environment/2779/4)