### PR TITLE
Add lifecycle ignore for disable_rollback

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -113,6 +113,9 @@ module Terrafying
         resource :aws_cloudformation_stack, ident,
                  name: ident,
                  disable_rollback: true,
+                 lifecycle: {
+                   ignore_changes: ['disable_rollback']
+                 },
                  template_body: generate_template(
                    options[:health_check], options[:instances], launch_config,
                    options[:subnets].map(&:id), tags, options[:rolling_update]


### PR DESCRIPTION
To avoid the problems like https://ci.usw.co/uswitch/terrafying-vault/1116/4 in cloudformation_stack