### PR TITLE
Bump prometheus to 2.25.0

### DIFF
--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -22,7 +22,7 @@ module Terrafying
         thanos_name: 'thanos',
         thanos_version: 'v0.18.0',
         prom_name: 'prometheus',
-        prom_version: 'v2.23.0',
+        prom_version: 'v2.25.0',
         instances: 2,
         instance_type: 't3a.small',
         thanos_instance_type: 't3a.small',


### PR DESCRIPTION
Upgrades default version of prometheus to 2.25.0

No breaking changes from 2.23.0 to 2.25.0:
https://github.com/prometheus/prometheus/releases/tag/v2.24.0
https://github.com/prometheus/prometheus/releases/tag/v2.25.0