### PR TITLE
Make content-type for objects that store cert and key latest folder as "text/plain"

### DIFF
--- a/lib/terrafying/components/letsencrypt.rb
+++ b/lib/terrafying/components/letsencrypt.rb
@@ -217,7 +217,8 @@ module Terrafying
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-key-latest",
                      bucket: @bucket,
                      key: object_key(name, :key, 'latest'),
-                     content: key_version
+                     content: key_version,
+                     content_type: "text/plain"
 
         cert_version = "${sha256(acme_certificate.#{key_ident}.certificate_pem)}"
 
@@ -233,7 +234,8 @@ module Terrafying
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert-latest",
                      bucket: @bucket,
                      key: object_key(name, :cert, 'latest'),
-                     content: cert_version
+                     content: cert_version,
+                     content_type: "text/plain"
 
         reference_keypair(ctx, name, key_version: key_version, cert_version: cert_version)
       end

--- a/lib/terrafying/components/selfsignedca.rb
+++ b/lib/terrafying/components/selfsignedca.rb
@@ -167,7 +167,8 @@ module Terrafying
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-key-latest",
                      bucket: @bucket,
                      key: object_key(name, :key, 'latest'),
-                     content: key_version
+                     content: key_version,
+                     content_type: "text/plain"
 
         cert_version = "${sha256(tls_locally_signed_cert.#{key_ident}.cert_pem)}"
         ctx.resource :aws_s3_bucket_object, object_name(name, :cert),
@@ -177,7 +178,8 @@ module Terrafying
         ctx.resource :aws_s3_bucket_object, "#{key_ident}-cert-latest",
                      bucket: @bucket,
                      key: object_key(name, :cert, 'latest'),
-                     content: cert_version
+                     content: cert_version,
+                     content_type: "text/plain"
 
         reference_keypair(ctx, name, key_version: key_version, cert_version: cert_version)
       end


### PR DESCRIPTION
In order for Terraform to be able to read an S3 bucket objects body, the content type has to be set to something that is human readable - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket_object

