### PR TITLE
Expose thanos to perform actions on it separate to Prom

### DIFF
--- a/lib/terrafying/components/prometheus.rb
+++ b/lib/terrafying/components/prometheus.rb
@@ -7,7 +7,7 @@ require 'terrafying/components'
 module Terrafying
   module Components
     class Prometheus < Terrafying::Context
-      attr_reader :prometheus, :security_group
+      attr_reader :prometheus, :security_group, :thanos
 
       def self.create_in(options)
         new(**options).tap(&:create)


### PR DESCRIPTION
Tested using `prom.thanos.used_by_cidr("10.50.0.0/16")` locally. This adds the cidr to the security group for Thanos