### PR TITLE
Bump Terraform to version 0.12.31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6.3-alpine3.9
 
 ARG TERRAFYING_VERSION=0.0.0
-ENV TERRAFORM_VERSION=0.12.29
+ENV TERRAFORM_VERSION=0.12.31
 
 RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
  && unzip terraform.zip \


### PR DESCRIPTION
For some reason, 0.12.29 cannot seem to download the AWS providers past 3.37.0. Bumping to the latest 0.12.31 version allows this. There are no breaking changes in the Terraform from 0.12.29 to 0.12.31 - https://github.com/hashicorp/terraform/blob/v0.12/CHANGELOG.md