### PR TITLE
Update AMI to latest base image

### DIFF
--- a/lib/terrafying/components/dynamicset.rb
+++ b/lib/terrafying/components/dynamicset.rb
@@ -33,7 +33,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-79994d1f', owners = ['477284023816']),
+          ami: aws.ami('base-image-fc-f50b677a', owners = ['477284023816']),
           instance_type: 't3a.micro',
           instances: { min: 1, max: 1, desired: 1, tags: {} },
           ports: [],

--- a/lib/terrafying/components/service.rb
+++ b/lib/terrafying/components/service.rb
@@ -41,7 +41,7 @@ module Terrafying
 
       def create_in(vpc, name, options = {})
         options = {
-          ami: aws.ami('base-image-fc-79994d1f', owners = ['477284023816']),
+          ami: aws.ami('base-image-fc-f50b677a', owners = ['477284023816']),
           instance_type: 't3a.micro',
           ports: [],
           instances: [{}],

--- a/lib/terrafying/components/staticset.rb
+++ b/lib/terrafying/components/staticset.rb
@@ -38,7 +38,7 @@ module Terrafying
         options = {
           public: false,
           eip: false,
-          ami: aws.ami('base-image-fc-79994d1f', owners = ['477284023816']),
+          ami: aws.ami('base-image-fc-f50b677a', owners = ['477284023816']),
           instance_type: 't3a.micro',
           subnets: vpc.subnets.fetch(:private, []),
           ports: [],


### PR DESCRIPTION
This new base image updates flatcar from `Flatcar-stable-2605.12.0-hvm` to `Flatcar-stable-2983.2.1-hvm`