### PR TITLE
SEC-487 AWSs examples are wrong, use not_starts_with matcher

### DIFF
--- a/lib/terrafying/components/security/trail.rb
+++ b/lib/terrafying/components/security/trail.rb
@@ -222,7 +222,7 @@ module Terrafying
               },
               {
                 field: 'resources.ARN',
-                not_equals: ignore_bucket_arns
+                not_starts_with: ignore_bucket_arns
               }
             ],
           }

--- a/spec/terrafying/components/security/trail_spec.rb
+++ b/spec/terrafying/components/security/trail_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Terrafying::Components::Security::Trail, '#create' do
                 field_selector: array_including(
                     {field: 'eventCategory',  equals: ['Data']},
                     {field: 'resources.type', equals: ['AWS::S3::Object']},
-                    {field: 'resources.ARN',  not_equals: array_including(bucket_arn)},
+                    {field: 'resources.ARN',  not_starts_with: array_including(bucket_arn)},
                 )
             )
         )


### PR DESCRIPTION
Apologies folks but AWS's own examples in their terraform provider docs are wrong.

The docs give this as an example of a selector that excludes buckets [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail).
```hcl
field_selector {
    field = "resources.ARN"

    not_equals = [
        "${data.aws_s3_bucket.not-important-bucket-1.arn}/",
        "${data.aws_s3_bucket.not-important-bucket-2.arn}/"
    ]
}
```

It's incorrect as `not_equals` actually needs to match the whole object to exclude it. This change uses `not_starts_with` instead.